### PR TITLE
docs/paypal-marks-radio-buttons

### DIFF
--- a/src/stories/PayPalMarks.stories.js
+++ b/src/stories/PayPalMarks.stories.js
@@ -62,7 +62,7 @@ function RadioButtonTemplate(args) {
                 {args.fundingSources.map((source, index) => (
                     <label className="mark" key={index}>
                         <input
-                            defaultChecked={index === 0 ? true : false}
+                            defaultChecked={index === 0}
                             onChange={onChange}
                             type="radio"
                             name="fundingSource"

--- a/src/stories/PayPalMarks.stories.js
+++ b/src/stories/PayPalMarks.stories.js
@@ -44,10 +44,31 @@ StandAlone.parameters = {
     },
 };
 
+const FormWithRadioButtons = (args) => {
+    const { fundingSources, onChange } = args;
+
+    return (
+        <form>
+            {fundingSources.map((source, index) => (
+                <label className="mark" key={index}>
+                    <input
+                        defaultChecked={index === 0 ? true : false}
+                        onChange={onChange}
+                        type="radio"
+                        name="fundingSource"
+                        value={source}
+                    />
+                    <PayPalMarks fundingSource={source} />
+                </label>
+            ))}
+        </form>
+    );
+};
+
 function RadioButtonTemplate(args) {
     const [fundingSource, setFundingSource] = useState(FUNDING.PAYPAL);
 
-    function onClick(event) {
+    function onChange(event) {
         setFundingSource(event.target.value);
     }
 
@@ -58,42 +79,14 @@ function RadioButtonTemplate(args) {
                 components: "buttons,marks,funding-eligibility",
             }}
         >
-            <form>
-                <label className="mark">
-                    <input
-                        onClick={onClick}
-                        type="radio"
-                        name="fundingSource"
-                        value={FUNDING.PAYPAL}
-                        defaultChecked
-                    />
-                    <PayPalMarks {...args} />
-                </label>
-
-                <label className="mark">
-                    <input
-                        onClick={onClick}
-                        type="radio"
-                        name="fundingSource"
-                        value={FUNDING.CARD}
-                    />
-                    <PayPalMarks fundingSource={FUNDING.CARD} />
-                </label>
-
-                <label className="mark">
-                    <input
-                        onClick={onClick}
-                        type="radio"
-                        name="fundingSource"
-                        value={FUNDING.PAYLATER}
-                    />
-                    <PayPalMarks fundingSource={FUNDING.PAYLATER} />
-                </label>
-            </form>
+            <FormWithRadioButtons {...args} onChange={onChange} />
+            <br />
             <PayPalButtons fundingSource={fundingSource} />
         </PayPalScriptProvider>
     );
 }
 
 export const RadioButtons = RadioButtonTemplate.bind({});
-RadioButtons.args = { fundingSource: FUNDING.PAYPAL };
+RadioButtons.args = {
+    fundingSources: [FUNDING.PAYPAL, FUNDING.CARD, FUNDING.PAYLATER],
+};

--- a/src/stories/PayPalMarks.stories.js
+++ b/src/stories/PayPalMarks.stories.js
@@ -44,27 +44,6 @@ StandAlone.parameters = {
     },
 };
 
-const FormWithRadioButtons = (args) => {
-    const { fundingSources, onChange } = args;
-
-    return (
-        <form>
-            {fundingSources.map((source, index) => (
-                <label className="mark" key={index}>
-                    <input
-                        defaultChecked={index === 0 ? true : false}
-                        onChange={onChange}
-                        type="radio"
-                        name="fundingSource"
-                        value={source}
-                    />
-                    <PayPalMarks fundingSource={source} />
-                </label>
-            ))}
-        </form>
-    );
-};
-
 function RadioButtonTemplate(args) {
     const [fundingSource, setFundingSource] = useState(FUNDING.PAYPAL);
 
@@ -79,7 +58,20 @@ function RadioButtonTemplate(args) {
                 components: "buttons,marks,funding-eligibility",
             }}
         >
-            <FormWithRadioButtons {...args} onChange={onChange} />
+            <form>
+                {args.fundingSources.map((source, index) => (
+                    <label className="mark" key={index}>
+                        <input
+                            defaultChecked={index === 0 ? true : false}
+                            onChange={onChange}
+                            type="radio"
+                            name="fundingSource"
+                            value={source}
+                        />
+                        <PayPalMarks fundingSource={source} />
+                    </label>
+                ))}
+            </form>
             <br />
             <PayPalButtons fundingSource={fundingSource} />
         </PayPalScriptProvider>


### PR DESCRIPTION
Hey team, great job on this lib!

I've updated `PayPalMarks.stories.js` to dynamically create the list of radio buttons as mentioned in [#31]

However. Arguably Storybook becomes less useful when you abstract DOM arrangement / creation into functions. E.g `FormWithRadioButtons` does indeed `map` over `fundingSources` to dynamically create the list of radio buttons but when you visit the "Show code" snippet the end _user_ can't see how those radio buttons / Paypal Marks have been created as they can't see the props being used to create the Story:

E.g looking at the "Show code" all we see is the `FormWithRadioButtons` component.

```javascript
...
  <FormWithRadioButtons
    fundingSources={[
      'paypal',
      'card',
      'paylater'
    ]}
    onChange={() => {}}
  />
...
</PayPalScriptProvider>
```


What might be a better approach is to _not_ abstract `FormWithRadioButtons`, but instead use the `map` "inline in the story"

```javascript
function RadioButtonTemplate(args) {
...
        <form>
            {args.fundingSources.map((source, index) => (
                <label className="mark" key={index}>
                    <input
                        defaultChecked={index === 0 ? true : false}
                        onChange={onChange}
                        type="radio"
                        name="fundingSource"
                        value={source}
                    />
                    <PayPalMarks fundingSource={source} />
                </label>
            ))}
        </form>
...
}
```

Which results in a more representative "Show code" snippet. 

E.g

```javascript
...
    <label className="mark">
      <input
        defaultChecked
        name="fundingSource"
        onChange={() => {}}
        type="radio"
        value="paypal"
      />
      <Marks fundingSource="paypal" />
    </label>
...
```

I'm happy to make that change and push again if you're in agreement?


On that note, it is then a little confusing that the usage for `PayPalMarks` is `<PayPalMarks />` but when exported and rendered in the "Show code" snippet it displays as `<Marks />`

I believe that comes from here [index.js#L2](https://github.com/paypal/react-paypal-js/blob/main/src/index.js#L2) and here [PayPalMarks.js#L26](https://github.com/paypal/react-paypal-js/blob/main/src/components/PayPalMarks.js#L26)

I wonder perhaps if declaring this component as `PayPalMarks` rather than `Marks` would solve that problem?

That said, this was fun. I'd like to continue to contribute as i'm a bit of a component library mega dweeb and love all these pedantic problems...

And finally, **naming things is hard**



