### PR TITLE
Update publish script

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,4 +1,5 @@
 const { exec } = require("shelljs");
+const readline = require("readline");
 
 // validate git and npm
 require("./validate");
@@ -13,8 +14,18 @@ exec(`npm version ${newVersionArg}`);
 // push up new version commit and tag
 exec("git push --follow-tags");
 
-// publish to public npm
-exec("npm publish");
+// use the readline module to simulate npm prompt
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+});
+
+// prompt for otp and publish to public npm
+rl.question("Enter OTP for public npm:", (otp) => {
+    exec(`npm publish --otp=${otp}`);
+
+    rl.close();
+});
 
 // deploy storybook to github pages
 exec("npm run deploy-storybook");

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -21,7 +21,7 @@ const rl = readline.createInterface({
 });
 
 // prompt for otp and publish to public npm
-rl.question("Enter OTP for public npm:", (otp) => {
+rl.question("Enter OTP for public npm: ", (otp) => {
     exec(`npm publish --otp=${otp}`);
 
     rl.close();

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -26,6 +26,3 @@ rl.question("Enter OTP for public npm:", (otp) => {
 
     rl.close();
 });
-
-// deploy storybook to github pages
-exec("npm run deploy-storybook");


### PR DESCRIPTION
## What
Updates the`publish.js` script to use a callback to pass in the OTP flag with `npm publish`.

This PR also removes the `npm run deploy-storybook` command. This is being replaced by a Github Action in an upcoming PR.

## Why
Attempting to run `npm publish` with the `exec` command from `shelljs` exits before allowing the user to enter an OTP. 2FA is required to publish to public npm, therefore the script did not work.