### PR TITLE
Add Github Action to deploy Storybook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,6 @@ jobs:
 
     - name: Build
       run: npm run build
+
+    - name: Build Storybook
+      run: npm run build-storybook

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,18 @@
+name: "Deploy Storybook to Github Pages"
+
+on:
+  push:
+    branches:
+      - main
+    paths: ["stories/**", "src/components/**"]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Deploy Storybook
+        run: npm run deploy-storybook

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -4,15 +4,20 @@ on:
   push:
     branches:
       - main
-    paths: ["stories/**", "src/components/**"]
+    paths: ["src/**", "README.md"]
 
 jobs:
   ci:
     runs-on: ubuntu-latest
 
-  steps:
+    steps:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Install dependencies
+      run: npm install
+
     - name: Deploy Storybook
-      run: npm run deploy-storybook
+      run: npm run deploy-storybook -- --ci
+      env:
+        GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,4 +15,4 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Deploy Storybook
-        run: npm run deploy-storybook
+      run: npm run deploy-storybook


### PR DESCRIPTION
## What
This PR adds a Github `storybook.yml` to deploy storybook on pushes/merges to main. It utilizes the [path workflow](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) which allows us to check for any changes to `src/` or the README (synced with our Getting Started page). This way we only deploy on main when there are changes available.

This PR also adds an update to`main.yml` to check storybook builds on every pull request.

## Why
Why _not_ automate storybook deploys?