### PR TITLE
Remove flat style from badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 React components for the [PayPal JS SDK](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/).
 
-<a href="https://www.npmjs.com/package/@paypal/react-paypal-js"><img src="https://img.shields.io/npm/v/@paypal/react-paypal-js?style=flat-square" alt="npm version"></a>
+<a href="https://www.npmjs.com/package/@paypal/react-paypal-js"><img src="https://img.shields.io/npm/v/@paypal/react-paypal-js" alt="npm version"></a>
 <a href="https://github.com/paypal/react-paypal-js/actions?query=workflow%3ACI"><img src="https://github.com/paypal/react-paypal-js/workflows/CI/badge.svg" alt="CI Status"></a>
-<a href="https://github.com/paypal/react-paypal-js/blob/main/LICENSE.txt"><img src="https://img.shields.io/npm/l/@paypal/react-paypal-js?style=flat-square" alt="github license"></a>
-<a href="https://david-dm.org/paypal/react-paypal-js"><img src="https://img.shields.io/david/paypal/react-paypal-js?style=flat-square" alt="dependencies"></a>
-<a href="https://david-dm.org/paypal/react-paypal-js?type=dev"><img src="https://img.shields.io/david/dev/paypal/react-paypal-js?style=flat-square" alt="dev dependencies"></a>
+<a href="https://david-dm.org/paypal/react-paypal-js"><img src="https://img.shields.io/david/paypal/react-paypal-js" alt="dependencies"></a>
+<a href="https://david-dm.org/paypal/react-paypal-js?type=dev"><img src="https://img.shields.io/david/dev/paypal/react-paypal-js" alt="dev dependencies"></a>
+<a href="https://github.com/paypal/react-paypal-js/blob/main/LICENSE.txt"><img src="https://img.shields.io/npm/l/@paypal/react-paypal-js" alt="GitHub license"></a>
 
 https://paypal.github.io/react-paypal-js/
 


### PR DESCRIPTION
The GitHub Actions badge doesn't have a flat style. This PR removes the flat style from the other badges so everything matches. Here's a screenshot of the new look:

<img width="809" alt="Screen Shot 2020-10-15 at 3 39 54 PM" src="https://user-images.githubusercontent.com/534034/96183677-d4d1d180-0efc-11eb-8b33-1c3dc8e97a41.png">
