### PR TITLE
Add 'resetOptions' action for dispatcher for reloading use case

### DIFF
--- a/__mocks__/@paypal/paypal-js.js
+++ b/__mocks__/@paypal/paypal-js.js
@@ -1,8 +1,23 @@
 import { loadScript as loadScriptOriginal } from "@paypal/paypal-js";
 
 export function loadScript(options) {
+    let scriptSrc;
+
+    // JSDOM does not support the HTMLScriptElement onload() callback since it doesn't actually load external scripts
+    // this code fakes the script onload() behavior by calling it whenever script.src property is set
+    Object.defineProperty(HTMLScriptElement.prototype, "src", {
+        get: jest.fn(() => scriptSrc),
+        set: jest.fn(function (src) {
+            scriptSrc = src;
+            setTimeout(() => {
+                window.paypal = window.paypal || {};
+                if (this.onload) this.onload();
+            });
+        }),
+    });
+
     return new Promise((resolve) => {
         loadScriptOriginal(options);
-        process.nextTick(() => resolve({}));
+        setTimeout(() => resolve({}));
     });
 }

--- a/src/ScriptContext.js
+++ b/src/ScriptContext.js
@@ -14,13 +14,8 @@ function scriptReducer(state, action) {
                 },
                 isLoaded: action.value,
             };
-        case "updateOptions":
-            return {
-                options: {
-                    ...state.options,
-                    ...action.value,
-                },
-            };
+        case "resetOptions":
+            return { options: action.value };
 
         // deprecated - remove for the v2 release
         case "changeCurrency":

--- a/src/ScriptContext.js
+++ b/src/ScriptContext.js
@@ -14,6 +14,15 @@ function scriptReducer(state, action) {
                 },
                 isLoaded: action.value,
             };
+        case "updateOptions":
+            return {
+                options: {
+                    ...state.options,
+                    ...action.value,
+                },
+            };
+
+        // deprecated - remove for the v2 release
         case "changeCurrency":
             return {
                 options: {

--- a/src/stories/Subscriptions.stories.js
+++ b/src/stories/Subscriptions.stories.js
@@ -15,17 +15,13 @@ export default {
 const scriptOptions = {
     "client-id": "sb",
     components: "buttons",
+    intent: "subscription",
+    vault: true,
 };
 
 function Template(args) {
-    const options = {
-        ...scriptOptions,
-        intent: "subscription",
-        vault: true,
-    };
-
     return (
-        <PayPalScriptProvider options={options}>
+        <PayPalScriptProvider options={scriptOptions}>
             <PayPalButtons {...args} />
         </PayPalScriptProvider>
     );
@@ -60,11 +56,7 @@ function TransactionTypeForm() {
         if (event.target.value === "subscription") {
             dispatch({
                 type: "resetOptions",
-                value: {
-                    ...scriptOptions,
-                    intent: "subscription",
-                    vault: true,
-                },
+                value: scriptOptions,
             });
         } else {
             dispatch({
@@ -86,18 +78,18 @@ function TransactionTypeForm() {
                     onChange={onChange}
                     type="radio"
                     name="type"
-                    value="order"
+                    value="subscription"
                 />
-                Order
+                Subscription
             </label>
             <label>
                 <input
                     onChange={onChange}
                     type="radio"
                     name="type"
-                    value="subscription"
+                    value="order"
                 />
-                Subscription
+                Order
             </label>
         </form>
     );

--- a/src/stories/Subscriptions.stories.js
+++ b/src/stories/Subscriptions.stories.js
@@ -1,5 +1,9 @@
 import React from "react";
-import { PayPalScriptProvider, PayPalButtons } from "../index";
+import {
+    PayPalScriptProvider,
+    PayPalButtons,
+    usePayPalScriptReducer,
+} from "../index";
 
 export default {
     title: "Example/Subscriptions",
@@ -34,3 +38,89 @@ Default.args = {
         label: "subscribe",
     },
 };
+
+function OrdersAndSubscriptionsTemplate(args) {
+    return (
+        <PayPalScriptProvider
+            options={{
+                "client-id": "sb",
+                components: "buttons",
+            }}
+        >
+            <TransactionTypeForm />
+            <br />
+            <CustomPayPalButtons {...args} />
+        </PayPalScriptProvider>
+    );
+}
+
+function TransactionTypeForm() {
+    const [, dispatch] = usePayPalScriptReducer();
+
+    function onChange(event) {
+        if (event.target.value === "subscription") {
+            dispatch({
+                type: "updateOptions",
+                value: {
+                    intent: "subscription",
+                    vault: true,
+                },
+            });
+        } else {
+            dispatch({
+                type: "updateOptions",
+                value: {
+                    intent: "order",
+                    vault: false,
+                },
+            });
+        }
+    }
+
+    return (
+        <form>
+            <label>
+                <input
+                    defaultChecked
+                    onChange={onChange}
+                    type="radio"
+                    name="type"
+                    value="order"
+                />
+                Order
+            </label>
+            <label>
+                <input
+                    onChange={onChange}
+                    type="radio"
+                    name="type"
+                    value="subscription"
+                />
+                Subscription
+            </label>
+        </form>
+    );
+}
+
+function CustomPayPalButtons(args) {
+    const [{ options }] = usePayPalScriptReducer();
+
+    const buttonOptions =
+        options.intent === "subscription"
+            ? {
+                  createSubscription: function (data, actions) {
+                      return actions.subscription.create({
+                          plan_id: "P-3RX065706M3469222L5IFM4I",
+                      });
+                  },
+                  style: {
+                      label: "subscribe",
+                  },
+              }
+            : {};
+
+    return <PayPalButtons {...{ ...args, ...buttonOptions }} />;
+}
+
+export const OrdersAndSubscriptions = OrdersAndSubscriptionsTemplate.bind({});
+OrdersAndSubscriptions.args = {};

--- a/src/stories/Subscriptions.stories.js
+++ b/src/stories/Subscriptions.stories.js
@@ -12,16 +12,20 @@ export default {
     },
 };
 
+const scriptOptions = {
+    "client-id": "sb",
+    components: "buttons",
+};
+
 function Template(args) {
+    const options = {
+        ...scriptOptions,
+        intent: "subscription",
+        vault: true,
+    };
+
     return (
-        <PayPalScriptProvider
-            options={{
-                "client-id": "sb",
-                intent: "subscription",
-                vault: true,
-                components: "buttons",
-            }}
-        >
+        <PayPalScriptProvider options={options}>
             <PayPalButtons {...args} />
         </PayPalScriptProvider>
     );
@@ -41,12 +45,7 @@ Default.args = {
 
 function OrdersAndSubscriptionsTemplate(args) {
     return (
-        <PayPalScriptProvider
-            options={{
-                "client-id": "sb",
-                components: "buttons",
-            }}
-        >
+        <PayPalScriptProvider options={scriptOptions}>
             <TransactionTypeForm />
             <br />
             <CustomPayPalButtons {...args} />
@@ -60,16 +59,18 @@ function TransactionTypeForm() {
     function onChange(event) {
         if (event.target.value === "subscription") {
             dispatch({
-                type: "updateOptions",
+                type: "resetOptions",
                 value: {
+                    ...scriptOptions,
                     intent: "subscription",
                     vault: true,
                 },
             });
         } else {
             dispatch({
-                type: "updateOptions",
+                type: "resetOptions",
                 value: {
+                    ...scriptOptions,
                     intent: "order",
                     vault: false,
                 },

--- a/src/stories/usePayPalScriptReducer.stories.js
+++ b/src/stories/usePayPalScriptReducer.stories.js
@@ -23,9 +23,14 @@ function Currency() {
     const [value, setValue] = useState(currency);
 
     function onChange(event) {
-        const value = event.target.value;
-        setValue(value);
-        dispatch({ type: "changeCurrency", value });
+        const selectedCurrency = event.target.value;
+        setValue(selectedCurrency);
+        dispatch({
+            type: "updateOptions",
+            value: {
+                currency: selectedCurrency,
+            },
+        });
     }
 
     return (

--- a/src/stories/usePayPalScriptReducer.stories.js
+++ b/src/stories/usePayPalScriptReducer.stories.js
@@ -10,7 +10,7 @@ export default {
     component: usePayPalScriptReducer,
 };
 
-const defaultOptions = {
+const scriptOptions = {
     "client-id": "sb",
     components: "buttons",
 };
@@ -26,8 +26,9 @@ function Currency() {
         const selectedCurrency = event.target.value;
         setValue(selectedCurrency);
         dispatch({
-            type: "updateOptions",
+            type: "resetOptions",
             value: {
+                ...scriptOptions,
                 currency: selectedCurrency,
             },
         });
@@ -54,7 +55,7 @@ function Template(args) {
 export const currencyUSD = Template.bind({});
 currencyUSD.args = {
     options: {
-        ...defaultOptions,
+        ...scriptOptions,
         currency: "USD",
     },
 };
@@ -62,7 +63,7 @@ currencyUSD.args = {
 export const currencyEUR = Template.bind({});
 currencyEUR.args = {
     options: {
-        ...defaultOptions,
+        ...scriptOptions,
         currency: "EUR",
     },
 };


### PR DESCRIPTION
This PR adds a generic `resetOptions` action for changing the sdk params with the dispatcher. The dispatcher is used for the reload use case. For example, the following use cases would use `resetOptions`:
- Updating currency
- Toggling the transaction type from Order to Subscription

Originally I added the `updateCurrency` action thinking each use case could have it's own specific action. Looking back, I think that was a mistake because there are so many different combinations of params that could be sent to the sdk, and we can't add a specific action for every use case. Instead, let's have one function that's able to set params and pass them through to paypal-js to reload the sdk. We can remove `updateCurrency` when we do a major version bump.