### PR TITLE
Catch and log errors from zoid render()

### DIFF
--- a/src/components/PayPalButtons.js
+++ b/src/components/PayPalButtons.js
@@ -22,9 +22,15 @@ export default function PayPalButtons(props) {
 
             buttons.current = window.paypal.Buttons({ ...props });
 
-            if (buttons.current.isEligible()) {
-                buttons.current.render(buttonsContainerRef.current);
+            if (!buttons.current.isEligible()) {
+                return;
             }
+
+            buttons.current.render(buttonsContainerRef.current).catch((err) => {
+                console.error(
+                    `Failed to render <PayPalButtons /> component. ${err}`
+                );
+            });
         } else {
             // close the buttons when the script is reloaded
             if (buttons.current) {

--- a/src/components/PayPalMarks.js
+++ b/src/components/PayPalMarks.js
@@ -34,9 +34,15 @@ export default function PayPalMarks(props) {
 
             mark.current = window.paypal.Marks({ ...props });
 
-            if (mark.current.isEligible()) {
-                mark.current.render(markContainerRef.current);
+            if (!mark.current.isEligible()) {
+                return;
             }
+
+            mark.current.render(markContainerRef.current).catch((err) => {
+                console.error(
+                    `Failed to render <PayPalMarks /> component. ${err}`
+                );
+            });
         }
     });
 

--- a/src/components/PayPalMessages.js
+++ b/src/components/PayPalMessages.js
@@ -4,12 +4,19 @@ import { usePayPalScriptReducer } from "../ScriptContext";
 export default function PayPalMessages(props) {
     const [{ isLoaded }] = usePayPalScriptReducer();
     const messagesContainerRef = useRef(null);
+    const messages = useRef(null);
 
     useEffect(() => {
         if (isLoaded) {
-            window.paypal
-                .Messages({ ...props })
-                .render(messagesContainerRef.current);
+            messages.current = window.paypal.Messages({ ...props });
+
+            messages.current
+                .render(messagesContainerRef.current)
+                .catch((err) => {
+                    console.error(
+                        `Failed to render <PayPalMessages /> component. ${err}`
+                    );
+                });
         }
     });
 

--- a/src/stories/PayPalButtons.stories.js
+++ b/src/stories/PayPalButtons.stories.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { FUNDING, PayPalScriptProvider, PayPalButtons } from "../index";
 
 export default {
@@ -84,3 +84,44 @@ StandAlone.parameters = {
         },
     },
 };
+
+function DynamicAmountTemplate(args) {
+    const [amount, setAmount] = useState(2);
+
+    function createOrder(data, actions) {
+        return actions.order.create({
+            purchase_units: [
+                {
+                    amount: {
+                        value: amount,
+                    },
+                },
+            ],
+        });
+    }
+
+    function onChange(event) {
+        const selectedAmount = event.target.value;
+        setAmount(selectedAmount);
+    }
+
+    return (
+        <PayPalScriptProvider options={defaultOptions}>
+            <select
+                onChange={onChange}
+                name="amount"
+                id="amount"
+                style={{ marginBottom: "20px" }}
+            >
+                <option value="2">$2.00</option>
+                <option value="4">$4.00</option>
+                <option value="6">$6.00</option>
+            </select>
+
+            <PayPalButtons {...args} createOrder={createOrder} />
+        </PayPalScriptProvider>
+    );
+}
+
+export const DynamicAmount = DynamicAmountTemplate.bind({});
+DynamicAmount.args = {};

--- a/src/stories/usePayPalScriptReducer.stories.js
+++ b/src/stories/usePayPalScriptReducer.stories.js
@@ -35,7 +35,13 @@ function Currency() {
     }
 
     return (
-        <select value={value} onChange={onChange} name="currency" id="currency">
+        <select
+            value={value}
+            onChange={onChange}
+            name="currency"
+            id="currency"
+            style={{ marginBottom: "20px" }}
+        >
             <option value="USD">United States dollar</option>
             <option value="EUR">Euro</option>
             <option value="CAD">Canadian dollar</option>


### PR DESCRIPTION
This PR fixes #45 by catching and logging any errors returned when rendering components. 

Under the hood, the PayPal JS SDK uses zoid and `render()` is actually an async function that returns a promise: https://github.com/krakenjs/zoid/issues/218#issuecomment-463884767. This PR catches render errors and logs them using `console.error()`.