### PR TITLE
Opt-out from using onShippingChange() callback with storybook demo

### DIFF
--- a/src/stories/PayPalButtons.stories.js
+++ b/src/stories/PayPalButtons.stories.js
@@ -8,6 +8,12 @@ export default {
         shippingPreference: { control: null },
         style: { control: null },
     },
+    args: {
+        // Storybook passes empty functions by default for props like `onShippingChange`.
+        // This turns on the `onShippingChange()` feature which uses the popup experience with the Standard Card button.
+        // We pass null to opt-out so the inline guest feature works as expected with the Standard Card button.
+        onShippingChange: null,
+    },
 };
 
 const defaultOptions = {

--- a/src/stories/PayPalMarks.stories.js
+++ b/src/stories/PayPalMarks.stories.js
@@ -73,7 +73,10 @@ function RadioButtonTemplate(args) {
                 ))}
             </form>
             <br />
-            <PayPalButtons fundingSource={fundingSource} />
+            <PayPalButtons
+                fundingSource={fundingSource}
+                style={{ color: "white" }}
+            />
         </PayPalScriptProvider>
     );
 }

--- a/src/stories/Subscriptions.stories.js
+++ b/src/stories/Subscriptions.stories.js
@@ -59,12 +59,12 @@ function TransactionTypeForm() {
                 value: scriptOptions,
             });
         } else {
+            const { "client-id": clientId, components } = scriptOptions;
             dispatch({
                 type: "resetOptions",
                 value: {
-                    ...scriptOptions,
-                    intent: "order",
-                    vault: false,
+                    "client-id": clientId,
+                    components,
                 },
             });
         }


### PR DESCRIPTION
This PR fixes #50 and makes sure the default inline guest feature works with the Standard Cards button for the [Buttons Storybook Demo](https://paypal.github.io/react-paypal-js/?path=/docs/example-paypalbuttons--default). Ex:

<img width="1017" alt="Screen Shot 2020-11-01 at 5 29 13 PM" src="https://user-images.githubusercontent.com/534034/97818449-19cd6600-1c68-11eb-9fcd-b8cea5336251.png">

This bug was only for the storybook demos. It turns out the storybook docs addon passes default values for props for component stories like the Buttons story even though we are not passing default prop type values. Passing default functions to most callbacks doesn't matter. But with the `onShippingChange` callback it does matter and using that option forces the user into the popup experience with the Standard Cards button. This PR passes null instead of a noop function to `onShippingChange` so the inline guest functionality works as expected. 