### PR TITLE
Remove shipping preferences prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div class="badges">
     <a href="https://www.npmjs.com/package/@paypal/react-paypal-js"><img src="https://img.shields.io/npm/v/@paypal/react-paypal-js" alt="npm version"></a>
-    <a href="https://www.npmjs.com/package/@paypal/react-paypal-js"><img src="https://img.shields.io/npm/dm/@paypal/react-paypal-js" alt="npm version"></a>
+    <a href="https://www.npmjs.com/package/@paypal/react-paypal-js"><img src="https://img.shields.io/npm/dm/@paypal/react-paypal-js" alt="npm downloads"></a>
     <a href="https://github.com/paypal/react-paypal-js/actions?query=workflow%3ACI"><img src="https://github.com/paypal/react-paypal-js/workflows/CI/badge.svg" alt="CI Status"></a>
     <a href="https://github.com/paypal/react-paypal-js/blob/main/LICENSE.txt"><img src="https://img.shields.io/npm/l/@paypal/react-paypal-js" alt="GitHub license"></a>
     <a href="https://paypal.github.io/react-paypal-js/"><img src="https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg"></a>

--- a/src/components/PayPalButtons.js
+++ b/src/components/PayPalButtons.js
@@ -45,13 +45,7 @@ export default function PayPalButtons(props) {
         });
 
         return cleanup;
-    }, [
-        isResolved,
-        props.forceReRender,
-        props.fundingSource,
-        props.shippingPreference,
-        props.style,
-    ]);
+    }, [isResolved, props.forceReRender, props.fundingSource, props.style]);
 
     return <div ref={buttonsContainerRef} />;
 }
@@ -110,18 +104,6 @@ PayPalButtons.propTypes = {
         tagline: PropTypes.bool,
     }),
     /**
-     * The possible values for shippingPreference are:
-     *
-     *    * `"NO_SHIPPING"`- Redact shipping address fields from the PayPal pages.
-     *    * `"GET_FROM_FILE"`- Use the buyer-selected shipping address.
-     *    * `"SET_PROVIDED_ADDRESS"`- Use the merchant-provided address.
-     */
-    shippingPreference: PropTypes.oneOf([
-        "GET_FROM_FILE",
-        "NO_SHIPPING",
-        "SET_PROVIDED_ADDRESS",
-    ]),
-    /**
      * Finalizes the transaction. Often used to show the buyer a [confirmation page](https://developer.paypal.com/docs/checkout/integration-features/confirmation-page/).
      */
     onApprove: PropTypes.func,
@@ -156,5 +138,4 @@ PayPalButtons.propTypes = {
 
 PayPalButtons.defaultProps = {
     style: {},
-    shippingPreference: "GET_FROM_FILE",
 };

--- a/src/components/PayPalButtons.test.js
+++ b/src/components/PayPalButtons.test.js
@@ -38,14 +38,12 @@ describe("<PayPalButtons />", () => {
                 <PayPalButtons
                     fundingSource={FUNDING.CREDIT}
                     style={{ layout: "horizontal" }}
-                    shippingPreference="GET_FROM_FILE"
                 />
             </PayPalScriptProvider>
         );
 
         await waitFor(() =>
             expect(window.paypal.Buttons).toHaveBeenCalledWith({
-                shippingPreference: "GET_FROM_FILE",
                 style: { layout: "horizontal" },
                 fundingSource: FUNDING.CREDIT,
             })

--- a/src/stories/PayPalButtons.stories.js
+++ b/src/stories/PayPalButtons.stories.js
@@ -5,7 +5,6 @@ export default {
     title: "Example/PayPalButtons",
     component: PayPalButtons,
     argTypes: {
-        shippingPreference: { control: null },
         style: { control: null },
     },
     args: {


### PR DESCRIPTION
I recently learned that `shippingPreference` is not a valid option for Buttons. This PR removes it.