### PR TITLE
Add github action for managing stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,27 @@
+name: "Close stale issues"
+on:
+    schedule:
+        - cron: "30 1 * * *"
+
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v3
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  days-before-stale: 45
+                  days-before-close: 5
+                  exempt-issue-labels: "awaiting-approval,work-in-progress"
+                  stale-issue-message: >
+                      This issue has been automatically marked as stale.
+                      **If this issue is still affecting you, please leave any comment** (for example, "bump"), and we'll keep it open.
+                      We are sorry that we haven't been able to prioritize it yet. If you have any new additional information, please include it with your comment!
+                  stale-pr-message: >
+                      This pull request has been automatically marked as stale.
+                      **If this pull request is still relevant, please leave any comment** (for example, "bump"), and we'll keep it open.
+                      We are sorry that we haven't been able to prioritize reviewing it yet. Your contribution is very much appreciated.
+                  close-issue-message: >
+                      Closing this issue after a prolonged period of inactivity. If this issue is still present in the latest release, please create a new issue with up-to-date information. Thank you!
+                  close-pr-message: >
+                      Closing this pull request after a prolonged period of inactivity. If this issue is still present in the latest release, please ask for this pull request to be reopened. Thank you!


### PR DESCRIPTION
This PR adds a new GitHub Action called [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues)

It's currently configured to label an issue or PR as stale after 45 days of no activity. And then close it out 5 days later if there's still no activity. I used the same polite messaging that React does for their automated issue management (https://github.com/facebook/react/blob/master/.github/stale.yml).

The plan is to test this out in react-paypal-js first. If it goes well then we can add it to more repos.