### PR TITLE
Use TypeScript

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,13 +1,20 @@
-module.exports = {
-    presets: [
-        ["@babel/preset-react"],
-        [
-            "@babel/preset-env",
-            {
-                targets: {
-                    node: "current",
-                },
-            },
+module.exports = (api) => {
+    const isTest = api.env("test");
+
+    if (isTest) {
+        return {
+            presets: [
+                ["@babel/preset-react"],
+                ["@babel/preset-env", { targets: { node: "current" } }],
+                "@babel/preset-typescript",
+            ],
+        };
+    }
+
+    return {
+        presets: [
+            ["@babel/preset-react"],
+            ["@babel/preset-env", { targets: { node: "current" } }],
         ],
-    ],
+    };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1182,12 +1182,13 @@
             }
         },
         "@babel/preset-typescript": {
-            "version": "7.12.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz",
-            "integrity": "sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==",
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.7.tgz",
+            "integrity": "sha512-nOoIqIqBmHBSEgBXWR4Dv/XBehtIFcw9PqZw6rFYuKrzsZmOQm3PR5siLBnKZFEsDb03IegG8nSjU/iXXXYRmw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-validator-option": "^7.12.1",
                 "@babel/plugin-transform-typescript": "^7.12.1"
             }
         },
@@ -2070,11 +2071,11 @@
             }
         },
         "@paypal/paypal-js": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-1.0.4.tgz",
-            "integrity": "sha512-zeIcVGqtH7oOVDihne+NfDmAAidQ4xjbb2JdWpS1H6wzDYdw3GwIB9m0srjj6rZuQx72l25UmTCHentkS1voTQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-2.1.2.tgz",
+            "integrity": "sha512-1Aimcg0GMv5Vt3u53PkVucSQs0lvr+Se2ZtdfLR1pW92ciGUoSx8moVy5zChLe7Zvyo9iZvsOtkM9k//r/l6IA==",
             "requires": {
-                "promise-polyfill": "^8.1.3"
+                "promise-polyfill": "^8.2.0"
             }
         },
         "@paypal/sdk-constants": {
@@ -2131,6 +2132,16 @@
             "requires": {
                 "@rollup/pluginutils": "^3.1.0",
                 "magic-string": "^0.25.7"
+            }
+        },
+        "@rollup/plugin-typescript": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.1.0.tgz",
+            "integrity": "sha512-pyQlcGQYRsONUDwXK3ckGPHjPzmjlq4sinzr7emW8ZMb2oZjg9WLcdcP8wyHSvBjvHrLzMayyPy079RROqb4vw==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^3.1.0",
+                "resolve": "^1.17.0"
             }
         },
         "@rollup/pluginutils": {
@@ -3393,9 +3404,9 @@
             }
         },
         "@types/react": {
-            "version": "16.9.56",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
-            "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
+            "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
             "dev": true,
             "requires": {
                 "@types/prop-types": "*",
@@ -17375,6 +17386,12 @@
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
+        },
+        "typescript": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "dev": true
         },
         "unfetch": {
             "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     ],
     "main": "dist/react-paypal.node.js",
     "module": "dist/react-paypal.esm.js",
+    "types": "dist/index.d.ts",
     "scripts": {
         "build": "rollup --config",
         "format": "prettier --write .",
@@ -25,7 +26,8 @@
         "release": "node ./scripts/publish",
         "release:patch": "node ./scripts/publish patch",
         "release:minor": "node ./scripts/publish minor",
-        "release:major": "node ./scripts/publish major"
+        "release:major": "node ./scripts/publish major",
+        "typecheck": "tsc --noEmit"
     },
     "files": [
         "dist"
@@ -36,7 +38,7 @@
         "url": "git://github.com/paypal/react-paypal-js.git"
     },
     "dependencies": {
-        "@paypal/paypal-js": "^1.0.4",
+        "@paypal/paypal-js": "^2.1.2",
         "@paypal/sdk-constants": "^1.0.77",
         "prop-types": "^15.7.2"
     },
@@ -44,15 +46,18 @@
         "@babel/core": "^7.12.3",
         "@babel/preset-env": "^7.12.1",
         "@babel/preset-react": "^7.12.5",
+        "@babel/preset-typescript": "^7.12.7",
         "@rollup/plugin-babel": "^5.2.1",
         "@rollup/plugin-node-resolve": "^10.0.0",
         "@rollup/plugin-replace": "^2.3.4",
+        "@rollup/plugin-typescript": "^8.1.0",
         "@storybook/addon-actions": "^6.0.28",
         "@storybook/addon-essentials": "^6.0.28",
         "@storybook/addon-links": "^6.0.28",
         "@storybook/react": "^6.0.28",
         "@storybook/storybook-deployer": "^2.8.7",
         "@testing-library/react": "^11.1.2",
+        "@types/react": "^17.0.0",
         "babel-jest": "^26.6.3",
         "babel-loader": "^8.2.1",
         "eslint": "^7.13.0",
@@ -67,7 +72,8 @@
         "react-dom": "^16.13.1",
         "react-is": "^17.0.1",
         "rollup": "^2.33.1",
-        "shelljs": "^0.8.4"
+        "shelljs": "^0.8.4",
+        "typescript": "^4.1.3"
     },
     "peerDependencies": {
         "react": ">=16.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,41 @@
 import babel, { getBabelOutputPlugin } from "@rollup/plugin-babel";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
 import pkg from "./package.json";
 
-export default {
-    input: "src/index.js",
-    plugins: [nodeResolve(), babel({ presets: ["@babel/preset-react"] })],
-    external: ["react", "prop-types"],
-    output: [
-        {
+const tsconfigOverride = {
+    exclude: ["node_modules", "**/*.test.ts"],
+};
+
+export default [
+    // CommonJS
+    {
+        input: "src/index.ts",
+        output: {
+            dir: "./",
+            entryFileNames: pkg.main,
+            format: "cjs",
+            globals: {
+                react: "React",
+            },
+        },
+        plugins: [
+            typescript({
+                declaration: true,
+                declarationDir: "dist/",
+                rootDir: "src/",
+                ...tsconfigOverride,
+            }),
+            nodeResolve(),
+            babel({ presets: ["@babel/preset-react"] }),
+        ],
+        external: ["react", "prop-types"],
+    },
+
+    // ESM
+    {
+        input: "src/index.ts",
+        output: {
             file: pkg.module,
             format: "esm",
             globals: {
@@ -19,12 +47,6 @@ export default {
                 }),
             ],
         },
-        {
-            file: pkg.main,
-            format: "cjs",
-            globals: {
-                react: "React",
-            },
-        },
-    ],
-};
+        plugins: [typescript({ ...tsconfigOverride })],
+    },
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,6 +51,6 @@ export default [
             ],
         },
         plugins: [typescript({ ...tsconfigOverride }), nodeResolve()],
-        external: ["react", "prop-types", "@paypal/sdk-constants/dist/module"],
+        external: ["react", "prop-types"],
     },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,10 @@ export default [
                 ...tsconfigOverride,
             }),
             nodeResolve(),
-            babel({ presets: ["@babel/preset-react"] }),
+            babel({
+                babelHelpers: "bundled",
+                presets: ["@babel/preset-react"],
+            }),
         ],
         external: ["react", "prop-types"],
     },
@@ -47,6 +50,7 @@ export default [
                 }),
             ],
         },
-        plugins: [typescript({ ...tsconfigOverride })],
+        plugins: [typescript({ ...tsconfigOverride }), nodeResolve()],
+        external: ["react", "prop-types", "@paypal/sdk-constants/dist/module"],
     },
 ];

--- a/src/ScriptContext.tsx
+++ b/src/ScriptContext.tsx
@@ -46,8 +46,7 @@ function scriptReducer(state: ScriptContextState, action: ScriptReducerAction) {
             };
 
         default: {
-            // @ts-expect-error - allow access to action.type
-            throw new Error(`Unhandled action type: ${action.type}`);
+            return state;
         }
     }
 }

--- a/src/components/PayPalButtons.test.js
+++ b/src/components/PayPalButtons.test.js
@@ -28,8 +28,8 @@ describe("<PayPalButtons />", () => {
         window.paypal = {
             Buttons: jest.fn(() => ({
                 close: jest.fn(),
-                isEligible: jest.fn(),
-                render: jest.fn(),
+                isEligible: jest.fn().mockReturnValue(true),
+                render: jest.fn().mockResolvedValue({}),
             })),
         };
 
@@ -54,8 +54,8 @@ describe("<PayPalButtons />", () => {
         window.paypal = {
             Buttons: jest.fn(() => ({
                 close: jest.fn(),
-                isEligible: jest.fn(),
-                render: jest.fn(),
+                isEligible: jest.fn().mockReturnValue(true),
+                render: jest.fn().mockResolvedValue({}),
             })),
         };
 
@@ -94,8 +94,8 @@ describe("<PayPalButtons />", () => {
         window.paypal = {
             Buttons: jest.fn(() => ({
                 close: jest.fn(),
-                isEligible: jest.fn(),
-                render: jest.fn(),
+                isEligible: jest.fn().mockReturnValue(true),
+                render: jest.fn().mockResolvedValue({}),
             })),
         };
 

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { usePayPalScriptReducer } from "../ScriptContext";
+import type { PayPalButtonsComponentProps } from "@paypal/paypal-js/types/components/buttons";
+
+interface PayPalButtonsReactProps extends PayPalButtonsComponentProps {
+    forceReRender?: unknown
+}
 /**
  * This `<PayPalButtons />` component renders the [Smart Payment Buttons](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#buttons).
  * It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
@@ -11,7 +16,7 @@ import { usePayPalScriptReducer } from "../ScriptContext";
  *     <PayPalButtons style={{ layout: "vertical" }} createOrder={(data, actions) => {}} />
  * ```
  */
-export default function PayPalButtons(props) {
+export default function PayPalButtons(props: PayPalButtonsReactProps) {
     const [{ isResolved, options }] = usePayPalScriptReducer();
     const buttonsContainerRef = useRef(null);
     const buttons = useRef(null);
@@ -20,6 +25,7 @@ export default function PayPalButtons(props) {
     useEffect(() => {
         const cleanup = () => {
             if (buttons.current) {
+                // @ts-expect-error - figure out types with useRef
                 buttons.current.close();
             }
         };
@@ -32,12 +38,15 @@ export default function PayPalButtons(props) {
             return cleanup;
         }
 
+        // @ts-expect-error - null checks
         buttons.current = window.paypal.Buttons({ ...props });
 
+        // @ts-expect-error - null checks
         if (!buttons.current.isEligible()) {
             return cleanup;
         }
 
+        // @ts-expect-error - null checks
         buttons.current.render(buttonsContainerRef.current).catch((err) => {
             console.error(
                 `Failed to render <PayPalButtons /> component. ${err}`
@@ -50,7 +59,9 @@ export default function PayPalButtons(props) {
     return <div ref={buttonsContainerRef} />;
 }
 
+// @ts-expect-error - figure out setErrorState
 function hasValidGlobalStateForButtons({ components = "" }, setErrorState) {
+    // @ts-expect-error - needs null checks
     if (typeof window.paypal.Buttons !== "undefined") {
         return true;
     }

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { usePayPalScriptReducer } from "../ScriptContext";
-import type { PayPalButtonsComponentProps, PayPalButtonsComponent } from "@paypal/paypal-js/types/components/buttons";
+import type {
+    PayPalButtonsComponentProps,
+    PayPalButtonsComponent,
+} from "@paypal/paypal-js/types/components/buttons";
 
 interface PayPalButtonsReactProps extends PayPalButtonsComponentProps {
-    forceReRender?: unknown
+    forceReRender?: unknown;
 }
 /**
  * This `<PayPalButtons />` component renders the [Smart Payment Buttons](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#buttons).
@@ -32,8 +35,11 @@ export default function PayPalButtons(props: PayPalButtonsReactProps) {
             return cleanup;
         }
 
-        // verify dependency on global state
-        if (window.paypal === undefined || window.paypal.Buttons === undefined) {
+        // verify dependency on window.paypal object
+        if (
+            window.paypal === undefined ||
+            window.paypal.Buttons === undefined
+        ) {
             setErrorState(() => {
                 throw new Error(getErrorMessage(options));
             });
@@ -65,7 +71,7 @@ export default function PayPalButtons(props: PayPalButtonsReactProps) {
 
 function getErrorMessage({ components = "" }) {
     let errorMessage =
-    "Unable to render <PayPalButtons /> because window.paypal.Buttons is undefined.";
+        "Unable to render <PayPalButtons /> because window.paypal.Buttons is undefined.";
 
     // the JS SDK includes the Buttons component by default when no 'components' are specified.
     // The 'buttons' component must be included in the 'components' list when using it with other components.

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -32,7 +32,7 @@ export default function PayPalButtons(props: PayPalButtonsReactProps) {
             return cleanup;
         }
 
-        // verify global state on window object
+        // verify dependency on global state
         if (window.paypal === undefined || window.paypal.Buttons === undefined) {
             setErrorState(() => {
                 throw new Error(getErrorMessage(options));
@@ -42,7 +42,7 @@ export default function PayPalButtons(props: PayPalButtonsReactProps) {
 
         buttons.current = window.paypal.Buttons({ ...props });
 
-        // only render the button when it's eligible
+        // only render the button when eligible
         if (buttons.current.isEligible() === false) {
             return cleanup;
         }
@@ -78,31 +78,6 @@ function getErrorMessage({ components = "" }) {
     }
 
     return errorMessage;
-}
-
-// @ts-expect-error - figure out setErrorState
-function hasValidGlobalStateForButtons({ components = "" }, setErrorState) {
-    // @ts-expect-error - needs null checks
-    if (typeof window.paypal.Buttons !== "undefined") {
-        return true;
-    }
-
-    let errorMessage =
-        "Unable to render <PayPalButtons /> because window.paypal.Buttons is undefined.";
-
-    // the JS SDK includes the Buttons component by default when no 'components' are specified.
-    // The 'buttons' component must be included in the 'components' list when using it with other components.
-    if (components.length && !components.includes("buttons")) {
-        const expectedComponents = `${components},buttons`;
-
-        errorMessage +=
-            "\nTo fix the issue, add 'buttons' to the list of components passed to the parent PayPalScriptProvider:" +
-            `\n\`<PayPalScriptProvider options={{ components: '${expectedComponents}'}}>\`.`;
-    }
-    setErrorState(() => {
-        throw new Error(errorMessage);
-    });
-    return false;
 }
 
 PayPalButtons.propTypes = {

--- a/src/components/PayPalMarks.test.js
+++ b/src/components/PayPalMarks.test.js
@@ -27,8 +27,8 @@ describe("<PayPalMarks />", () => {
     test("should pass props to window.paypal.Marks()", async () => {
         window.paypal = {
             Marks: jest.fn(() => ({
-                isEligible: jest.fn(),
-                render: jest.fn(),
+                isEligible: jest.fn().mockReturnValue(true),
+                render: jest.fn().mockResolvedValue({}),
             })),
         };
 

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { usePayPalScriptReducer } from "../ScriptContext";
-import type { PayPalMarksComponentProps, PayPalMarksComponent } from "@paypal/paypal-js/types/components/marks";
+import type {
+    PayPalMarksComponentProps,
+    PayPalMarksComponent,
+} from "@paypal/paypal-js/types/components/marks";
 
 /**
  * The `<PayPalMarks />` component is used for conditionally rendering different payment options using radio buttons.
@@ -42,7 +45,7 @@ export default function PayPalMarks(props: PayPalMarksComponentProps) {
             return;
         }
 
-        // verify dependency on global state
+        // verify dependency on window.paypal object
         if (window.paypal === undefined || window.paypal.Marks === undefined) {
             setErrorState(() => {
                 throw new Error(getErrorMessage(options));

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { usePayPalScriptReducer } from "../ScriptContext";
+import type { PayPalMarksComponentProps } from "@paypal/paypal-js/types/components/marks";
+
 /**
  * The `<PayPalMarks />` component is used for conditionally rendering different payment options using radio buttons.
  * The [Display PayPal Buttons with other Payment Methods guide](https://developer.paypal.com/docs/business/checkout/add-capabilities/buyer-experience/#display-paypal-buttons-with-other-payment-methods) describes this style of integration in detail.
@@ -23,7 +25,7 @@ import { usePayPalScriptReducer } from "../ScriptContext";
  *     <PayPalMarks fundingSource={FUNDING.PAYPAL}/>
  * ```
  */
-export default function PayPalMarks(props) {
+export default function PayPalMarks(props: PayPalMarksComponentProps) {
     const [{ isResolved, options }] = usePayPalScriptReducer();
     const markContainerRef = useRef(null);
     const mark = useRef(null);
@@ -38,12 +40,15 @@ export default function PayPalMarks(props) {
             return;
         }
 
+        // @ts-expect-error - null checks
         mark.current = window.paypal.Marks({ ...props });
 
+        // @ts-expect-error - null checks
         if (!mark.current.isEligible()) {
             return;
         }
 
+        // @ts-expect-error - null checks
         mark.current.render(markContainerRef.current).catch((err) => {
             console.error(`Failed to render <PayPalMarks /> component. ${err}`);
         });
@@ -52,7 +57,9 @@ export default function PayPalMarks(props) {
     return <div ref={markContainerRef} />;
 }
 
+// @ts-expect-error - figure out setErrorState
 function hasValidStateForMarks({ components = "" }, setErrorState) {
+    // @ts-expect-error - needs null checks
     if (typeof window.paypal.Marks !== "undefined") {
         return true;
     }

--- a/src/components/PayPalMessages.tsx
+++ b/src/components/PayPalMessages.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useRef } from "react";
 import { usePayPalScriptReducer } from "../ScriptContext";
+import type { PayPalMessagesComponentProps } from "@paypal/paypal-js/types/components/messages";
 
-export default function PayPalMessages(props) {
+interface PayPalMessagesReactProps extends PayPalMessagesComponentProps {
+    forceReRender?: unknown
+}
+
+export default function PayPalMessages(props: PayPalMessagesReactProps) {
     const [{ isResolved }] = usePayPalScriptReducer();
     const messagesContainerRef = useRef(null);
     const messages = useRef(null);
@@ -11,8 +16,10 @@ export default function PayPalMessages(props) {
             return;
         }
 
+        // @ts-expect-error - null checks
         messages.current = window.paypal.Messages({ ...props });
 
+        // @ts-expect-error - null checks
         messages.current.render(messagesContainerRef.current).catch((err) => {
             console.error(
                 `Failed to render <PayPalMessages /> component. ${err}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
+import { any } from "prop-types";
+
 export { default as PayPalButtons } from "./components/PayPalButtons";
+
 export { default as PayPalMarks } from "./components/PayPalMarks";
 export { default as PayPalMessages } from "./components/PayPalMessages";
 export * from "./ScriptContext";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,4 @@
-import { any } from "prop-types";
-
 export { default as PayPalButtons } from "./components/PayPalButtons";
-
 export { default as PayPalMarks } from "./components/PayPalMarks";
 export { default as PayPalMessages } from "./components/PayPalMessages";
 export * from "./ScriptContext";

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,3 @@
+declare module '@paypal/sdk-constants/dist/module' {
+    export const FUNDING: Record<string, string>;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,3 @@
-declare module '@paypal/sdk-constants/dist/module' {
+declare module "@paypal/sdk-constants/dist/module" {
     export const FUNDING: Record<string, string>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "allowJs": false,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "module": "esnext",
+        "moduleResolution": "node",
+        "target": "esnext",
+        "strict": true,
+
+        // these are overridden by the Rollup plugin
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
Happy new year everyone! I come bearing the gift of types 🎁 

### Screenshots

<img width="970" alt="script-options-screenshot" src="https://user-images.githubusercontent.com/534034/104132188-45905a80-5341-11eb-9fd9-bbb96f13f883.png">

<img width="1097" alt="buttons-screenshot" src="https://user-images.githubusercontent.com/534034/104132198-54770d00-5341-11eb-99a2-a73158b584bc.png">

### How to Test

Use the latest beta to test out the types:

```
npm install @paypal/react-paypal-js@beta
```

### Additional Info

There are a lot of `@ts-expect-error` statements being used to avoid compile time errors. These are code smells and should be cleaned up before merging this PR. I could use some help with this. I would gladly accept PRs to this "typescript" branch.

I decided to keep the Proptypes with the idea that they are for runtime validation and the TypeScript types are for compile time validation. For more info see: https://stackoverflow.com/a/54690878

Related issues: #69 #53