### PR TITLE
Do not throw button render errors when ref is invalid

### DIFF
--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -88,9 +88,15 @@ export default function PayPalButtons({
         }
 
         buttons.current.render(buttonsContainerRef.current).catch((err) => {
-            console.error(
-                `Failed to render <PayPalButtons /> component. ${err}`
-            );
+            // component failed to render, possibly because it was closed or destroyed.
+            if (buttonsContainerRef.current === null) {
+                // ref is no longer in the DOM, we can safely ignore the error
+                return;
+            }
+            // ref is still in the DOM
+            setErrorState(() => {
+                throw new Error(`Failed to render <PayPalButtons /> component. ${err}`);
+            });
         });
 
         return closeButtonsComponent;

--- a/src/components/__snapshots__/PayPalButtons.test.js.snap
+++ b/src/components/__snapshots__/PayPalButtons.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<PayPalButtons /> should catch and log zoid render errors 1`] = `"Failed to render <PayPalButtons /> component. Window closed"`;
+
 exports[`<PayPalButtons /> should throw an error when no components are passed to the PayPalScriptProvider 1`] = `"Unable to render <PayPalButtons /> because window.paypal.Buttons is undefined."`;
 
 exports[`<PayPalButtons /> should throw an error when the 'buttons' component is missing from the components list passed to the PayPalScriptProvider 1`] = `


### PR DESCRIPTION
This PR attempts to limit rendering errors related to the Buttons container being removed before async rendering completes. It's inspired by this PR for the zoid react driver that ships with the JS SDK: https://github.com/krakenjs/zoid/pull/335.

Related: #85