### PR TITLE
fix: typescript type for `ScriptReducerAction`

### DIFF
--- a/src/ScriptContext.tsx
+++ b/src/ScriptContext.tsx
@@ -19,9 +19,11 @@ enum SCRIPT_LOADING_STATE {
     RESOLVED = "resolved",
 }
 
+type ScriptLoadingState = `${SCRIPT_LOADING_STATE}`;
+
 interface ScriptContextState {
     options: ReactPayPalScriptOptions;
-    loadingStatus: SCRIPT_LOADING_STATE;
+    loadingStatus: SCRIPT_LOADING_STATE | ScriptLoadingState;
 }
 
 interface ScriptContextDerivedState {
@@ -33,7 +35,10 @@ interface ScriptContextDerivedState {
 }
 
 type ScriptReducerAction =
-    | { type: "setLoadingStatus"; value: SCRIPT_LOADING_STATE }
+    | {
+          type: "setLoadingStatus";
+          value: SCRIPT_LOADING_STATE | ScriptLoadingState;
+      }
     | { type: "resetOptions"; value: ReactPayPalScriptOptions };
 
 type ScriptReducerDispatch = (action: ScriptReducerAction) => void;

--- a/src/ScriptContext.tsx
+++ b/src/ScriptContext.tsx
@@ -12,18 +12,18 @@ export interface ReactPayPalScriptOptions extends PayPalScriptOptions {
     "data-react-paypal-script-id": string;
 }
 
-enum SCRIPT_LOADING_STATE {
-    INITIAL = "initial",
-    PENDING = "pending",
-    REJECTED = "rejected",
-    RESOLVED = "resolved",
-}
+const SCRIPT_LOADING_STATE = {
+    INITIAL: "initial",
+    PENDING: "pending",
+    REJECTED: "rejected",
+    RESOLVED: "resolved",
+} as const;
 
-type ScriptLoadingState = `${SCRIPT_LOADING_STATE}`;
+type ScriptLoadingState = typeof SCRIPT_LOADING_STATE[keyof typeof SCRIPT_LOADING_STATE];
 
 interface ScriptContextState {
     options: ReactPayPalScriptOptions;
-    loadingStatus: SCRIPT_LOADING_STATE | ScriptLoadingState;
+    loadingStatus: ScriptLoadingState;
 }
 
 interface ScriptContextDerivedState {
@@ -37,7 +37,7 @@ interface ScriptContextDerivedState {
 type ScriptReducerAction =
     | {
           type: "setLoadingStatus";
-          value: SCRIPT_LOADING_STATE | ScriptLoadingState;
+          value: ScriptLoadingState;
       }
     | { type: "resetOptions"; value: ReactPayPalScriptOptions };
 


### PR DESCRIPTION
- Created `ScriptLoadingState` type from the union of the enum `SCRIPT_LOADING_STATE` and used it 
as a possible values for `setLoadingStatus` to avoid type error when passing a valid string value on the dispatch function.