### PR TITLE
feat(storybook): add support for overriding js sdk query params

### DIFF
--- a/src/stories/PayPalButtons.stories.js
+++ b/src/stories/PayPalButtons.stories.js
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
 import { FUNDING, PayPalScriptProvider, PayPalButtons } from "../index";
+import { getOptionsFromQueryString } from "./utils";
 
 const scriptProviderOptions = {
     "client-id": "test",
     components: "buttons",
+    ...getOptionsFromQueryString(),
 };
 
 export default {

--- a/src/stories/PayPalMarks.stories.js
+++ b/src/stories/PayPalMarks.stories.js
@@ -5,10 +5,12 @@ import {
     PayPalButtons,
     FUNDING,
 } from "../index";
+import { getOptionsFromQueryString } from "./utils";
 
 const scriptProviderOptions = {
     "client-id": "test",
     components: "buttons,marks,funding-eligibility",
+    ...getOptionsFromQueryString(),
 };
 
 export default {

--- a/src/stories/PayPalMessages.stories.js
+++ b/src/stories/PayPalMessages.stories.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { PayPalScriptProvider, PayPalMessages } from "../index";
+import { getOptionsFromQueryString } from "./utils";
 
 const scriptProviderOptions = {
     "client-id": "test",
     components: "messages",
+    ...getOptionsFromQueryString(),
 };
 
 export default {

--- a/src/stories/Subscriptions.stories.js
+++ b/src/stories/Subscriptions.stories.js
@@ -4,12 +4,14 @@ import {
     PayPalButtons,
     usePayPalScriptReducer,
 } from "../index";
+import { getOptionsFromQueryString } from "./utils";
 
 const scriptProviderOptions = {
     "client-id": "test",
     components: "buttons",
     intent: "subscription",
     vault: true,
+    ...getOptionsFromQueryString(),
 };
 
 export default {

--- a/src/stories/VenmoButton.stories.js
+++ b/src/stories/VenmoButton.stories.js
@@ -1,11 +1,14 @@
 import React from "react";
 import { FUNDING, PayPalScriptProvider, PayPalButtons } from "../index";
+import { getOptionsFromQueryString } from "./utils";
 
 const scriptProviderOptions = {
     "client-id":
         "AdLzRW18VHoABXiBhpX2gf0qhXwiW4MmFVHL69V90vciCg_iBLGyJhlf7EuWtFcdNjGiDfrwe7rmhvMZ",
     components: "buttons,funding-eligibility",
     "enable-funding": "venmo",
+    debug: true,
+    ...getOptionsFromQueryString(),
 };
 
 export default {

--- a/src/stories/utils.js
+++ b/src/stories/utils.js
@@ -1,0 +1,14 @@
+const StorybookQueryParametersToIgnore = ["path", "id", "args", "viewMode"];
+
+export function getOptionsFromQueryString() {
+    const searchParams = new URLSearchParams(window.location.search) || [];
+
+    return Array.from(searchParams)
+        .filter(([key]) => {
+            return !StorybookQueryParametersToIgnore.includes(key);
+        })
+        .reduce((acc, [key, value]) => {
+            acc[key] = value;
+            return acc;
+        }, {});
+}


### PR DESCRIPTION
This PR updates the storybook demo site to pass query string params through to the JS SDK. 

For example, when running locally and you can pass a custom `client-id` and `components` list in the query string and the JS SDK will apply that:
http://localhost:6006/?path=/story/example-paypalbuttons--default&client-id=sb&components=buttons,messages,hosted-fields

<img width="1265" alt="Screen Shot 2021-06-15 at 11 14 54 AM" src="https://user-images.githubusercontent.com/534034/122088345-3e2b1c80-cdcb-11eb-9ab9-59b58fa21a89.png">
