### PR TITLE
fix: type declarations don’t depend on internal typings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,10 @@ export * from "./components/PayPalMarks";
 export * from "./components/PayPalMessages";
 export * from "./ScriptContext";
 
-export { FUNDING } from "@paypal/sdk-constants/dist/module";
+import * as constants from "@paypal/sdk-constants/dist/module";
+
+// We do not re-export `FUNDING` from the `sdk-constants` module
+// directly because it has no type definitions.
+//
+// See https://github.com/paypal/react-paypal-js/issues/125
+export const FUNDING: Record<string, string> = constants.FUNDING;


### PR DESCRIPTION
We prevent typescript from generating declarations that reference the `@paypal/sdk-constants` package. This package does not provide types, instead we use our own type declarations in `./src/types.d.ts`. These declarations are not available to users of the library.

Fixes https://github.com/paypal/react-paypal-js/issues/125