### PR TITLE
fix(release): do not publish types from storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "format": "prettier --write .",
         "lint": "eslint .",
         "postinstall": "husky install",
-        "prepack": "rimraf dist && npm run build && npx tsc --emitDeclarationOnly --outDir dist/types",
+        "prepack": "rimraf dist && npm run build && npm run type-declarations",
         "prepublishOnly": "pinst --disable",
         "postpublish": "pinst --enable",
         "test": "jest --env=jsdom",
@@ -30,6 +30,7 @@
         "deploy-storybook": "storybook-to-ghpages",
         "release": "node ./scripts/publish",
         "typecheck": "tsc --noEmit",
+        "type-declarations": "tsc --emitDeclarationOnly --outDir dist/types --project tsconfig.declarations.json",
         "validate": "npm run typecheck && npm run build && npm run lint && npm test -- --coverage"
     },
     "files": [

--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src"],
+    "exclude": ["src/stories"]
+}


### PR DESCRIPTION
I noticed that types for the storybook stories were being included in the generated declarations. This PR adds a new typescript config to exclude them.

cc: @geigerzaehler