### PR TITLE
PayPalMarks allows re-render on fundingSource changes

### DIFF
--- a/src/components/PayPalMarks.test.js
+++ b/src/components/PayPalMarks.test.js
@@ -160,31 +160,24 @@ describe("<PayPalMarks />", () => {
         spyConsoleError.mockRestore();
     });
 
-    test("should not render component when is not eligible", async () => {
+    test("should not render component when ineligible", async () => {
+        const mockIsEligible = jest.fn().mockReturnValue(false);
+        const mockRender = jest.fn().mockResolvedValue();
+
         // Make Marks not eligible
         window.paypal.Marks = () => ({
-            isEligible: jest.fn().mockReturnValue(false),
-            render: (element) => {
-                const spanElement = document.createElement("span");
-
-                spanElement.setAttribute("id", "span-element");
-                element.append(spanElement);
-                return Promise.resolve();
-            },
+            isEligible: mockIsEligible,
+            render: mockRender,
         });
 
-        const { container } = render(
+        render(
             <PayPalScriptProvider options={{ "client-id": "test" }}>
                 <PayPalMarks />
             </PayPalScriptProvider>
         );
 
-        await waitFor(() =>
-            expect(
-                container.querySelector("#span-element") instanceof
-                    HTMLDivElement
-            ).toBeFalsy()
-        );
+        await waitFor(() => expect(mockIsEligible).toBeCalled());
+        expect(mockRender).not.toBeCalled();
     });
 
     test("should rerender the component when the funding source change", async () => {

--- a/src/components/PayPalMarks.test.js
+++ b/src/components/PayPalMarks.test.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 import { render, waitFor } from "@testing-library/react";
 
 import { PayPalScriptProvider } from "../components/PayPalScriptProvider.tsx";

--- a/src/components/PayPalMarks.test.js
+++ b/src/components/PayPalMarks.test.js
@@ -11,15 +11,6 @@ jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),
 }));
 
-jest.mock("react", () => ({
-    ...jest.requireActual("react"),
-    useRef: jest.fn().mockReturnValue({
-        current: {
-            firstChild: "mio",
-        },
-    }),
-}));
-
 const onError = jest.fn();
 const wrapper = ({ children }) => (
     <ErrorBoundary fallback={<div>Error</div>} onError={onError}>

--- a/src/components/PayPalMarks.test.js
+++ b/src/components/PayPalMarks.test.js
@@ -195,4 +195,36 @@ describe("<PayPalMarks />", () => {
             ).toBeFalsy()
         );
     });
+
+    test("should rerender the component when the funding source change", async () => {
+        window.paypal.Marks = () => ({
+            isEligible: jest.fn().mockReturnValue(true),
+            render: (element) => {
+                const markElement = document.createElement("div");
+
+                markElement.setAttribute("id", "children-div");
+                element.append(markElement);
+                return Promise.resolve();
+            },
+        });
+
+        const { container, rerender } = render(
+            <PayPalScriptProvider options={{ "client-id": "test" }}>
+                <PayPalMarks fundingSource="paypal" />
+            </PayPalScriptProvider>
+        );
+
+        await waitFor(() =>
+            expect(
+                container.querySelector("#children-div") instanceof
+                    HTMLDivElement
+            ).toBeTruthy()
+        );
+
+        rerender(
+            <PayPalScriptProvider options={{ "client-id": "test" }}>
+                <PayPalMarks fundingSource="card" />
+            </PayPalScriptProvider>
+        );
+    });
 });

--- a/src/components/PayPalMarks.test.js
+++ b/src/components/PayPalMarks.test.js
@@ -163,8 +163,6 @@ describe("<PayPalMarks />", () => {
     test("should not render component when ineligible", async () => {
         const mockIsEligible = jest.fn().mockReturnValue(false);
         const mockRender = jest.fn().mockResolvedValue();
-
-        // Make Marks not eligible
         window.paypal.Marks = () => ({
             isEligible: mockIsEligible,
             render: mockRender,

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -39,49 +39,32 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
     const [, setErrorState] = useState(null);
 
     /**
-     * Remove any instance of the PayPal Mark from the DOM
-     */
-    const removeCurrentPayPalMark = () => {
-        if (
-            markContainerRef.current !== null &&
-            markContainerRef.current.firstChild != null
-        ) {
-            markContainerRef.current.removeChild(
-                markContainerRef.current.firstChild
-            );
-        }
-    };
-
-    /**
      * Render PayPal Mark into the DOM
      */
     const renderPayPalMark = (mark: PayPalMarksComponent) => {
-        removeCurrentPayPalMark();
-        // only render the mark when eligible
-        if (
-            (mark != null && mark.isEligible()) === false ||
-            markContainerRef.current == null
-        )
-            return;
+        const { current } = markContainerRef;
 
-        if (mark && markContainerRef.current) {
-            mark.render(markContainerRef.current).catch((err) => {
-                // component failed to render, possibly because it was closed or destroyed.
-                if (
-                    markContainerRef.current === null ||
-                    markContainerRef.current.children.length === 0
-                ) {
-                    // paypal marks container is no longer in the DOM, we can safely ignore the error
-                    return;
-                }
-                // paypal marks container is still in the DOM
-                setErrorState(() => {
-                    throw new Error(
-                        `Failed to render <PayPalMarks /> component. ${err}`
-                    );
-                });
+        // only render the mark when eligible
+        if ((mark != null && mark.isEligible()) === false || current == null)
+            return;
+        // Remove any children before
+        if (current !== null && current.firstChild != null)
+            /* istanbul ignore next */ // Can't find a solution to test the next line
+            current.removeChild(current.firstChild);
+
+        mark.render(current).catch((err) => {
+            // component failed to render, possibly because it was closed or destroyed.
+            if (current === null || current.children.length === 0) {
+                // paypal marks container is no longer in the DOM, we can safely ignore the error
+                return;
+            }
+            // paypal marks container is still in the DOM
+            setErrorState(() => {
+                throw new Error(
+                    `Failed to render <PayPalMarks /> component. ${err}`
+                );
             });
-        }
+        });
     };
 
     useEffect(() => {

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -47,9 +47,7 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
         // only render the mark when eligible
         if (!current || !mark.isEligible()) return;
         // Remove any children before render it again
-        if (current.firstChild)
-            /* istanbul ignore next */ // Can't find a solution to test the next line
-            current.removeChild(current.firstChild);
+        if (current.firstChild) current.removeChild(current.firstChild);
 
         mark.render(current).catch((err) => {
             // component failed to render, possibly because it was closed or destroyed.

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -45,10 +45,9 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
         const { current } = markContainerRef;
 
         // only render the mark when eligible
-        if ((mark != null && mark.isEligible()) === false || current == null)
-            return;
-        // Remove any children before
-        if (current !== null && current.firstChild != null)
+        if (!current || !mark.isEligible()) return;
+        // Remove any children before render it again
+        if (current.firstChild)
             /* istanbul ignore next */ // Can't find a solution to test the next line
             current.removeChild(current.firstChild);
 

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -36,7 +36,6 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
 }: PayPalMarksComponentProps) => {
     const [{ isResolved, options }] = usePayPalScriptReducer();
     const markContainerRef = useRef<HTMLDivElement>(null);
-    const mark = useRef<PayPalMarksComponent | null>(null);
     const [, setErrorState] = useState(null);
 
     /**
@@ -56,10 +55,17 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
     /**
      * Render PayPal Mark into the DOM
      */
-    const renderPayPalMark = () => {
+    const renderPayPalMark = (mark: PayPalMarksComponent) => {
         removeCurrentPayPalMark();
-        if (mark.current && markContainerRef.current) {
-            mark.current.render(markContainerRef.current).catch((err) => {
+        // only render the mark when eligible
+        if (
+            (mark != null && mark.isEligible()) === false ||
+            markContainerRef.current == null
+        )
+            return;
+
+        if (mark && markContainerRef.current) {
+            mark.render(markContainerRef.current).catch((err) => {
                 // component failed to render, possibly because it was closed or destroyed.
                 if (
                     markContainerRef.current === null ||
@@ -97,16 +103,7 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
             return;
         }
 
-        mark.current = paypalWindowNamespace.Marks({ ...markProps });
-
-        // only render the mark when eligible
-        if (
-            mark.current.isEligible() === false ||
-            markContainerRef.current == null
-        )
-            return;
-
-        renderPayPalMark();
+        renderPayPalMark(paypalWindowNamespace.Marks({ ...markProps }));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isResolved, markProps.fundingSource]);
 

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -47,7 +47,9 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
         // only render the mark when eligible
         if (!current || !mark.isEligible()) return;
         // Remove any children before render it again
-        if (current.firstChild) current.removeChild(current.firstChild);
+        if (current.firstChild) {
+            current.removeChild(current.firstChild);
+        }
 
         mark.render(current).catch((err) => {
             // component failed to render, possibly because it was closed or destroyed.

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -18,17 +18,13 @@ export interface PayPalMarksComponentProps extends PayPalMarksComponentOptions {
 The `<PayPalMarks />` component is used for conditionally rendering different payment options using radio buttons.
 The [Display PayPal Buttons with other Payment Methods guide](https://developer.paypal.com/docs/business/checkout/add-capabilities/buyer-experience/#display-paypal-buttons-with-other-payment-methods) describes this style of integration in detail.
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
-
 ```jsx
     <PayPalMarks />
 ```
-
 This component can also be configured to use a single funding source similar to the [standalone buttons](https://developer.paypal.com/docs/business/checkout/configure-payments/standalone-buttons/) approach.
 A `FUNDING` object is exported by this library which has a key for every available funding source option.
-
 ```jsx
     import { PayPalScriptProvider, PayPalMarks, FUNDING } from "@paypal/react-paypal-js";
-
     <PayPalScriptProvider options={{ "client-id": "test", components: "buttons,marks" }}>
         <PayPalMarks fundingSource={FUNDING.PAYPAL}/>
     </PayPalScriptProvider>
@@ -43,16 +39,48 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
     const mark = useRef<PayPalMarksComponent | null>(null);
     const [, setErrorState] = useState(null);
 
+    /**
+     * Remove any instance of the PayPal Mark from the DOM
+     */
+    const removeCurrentPayPalMark = () => {
+        if (
+            markContainerRef.current !== null &&
+            markContainerRef.current.firstChild != null
+        ) {
+            markContainerRef.current.removeChild(
+                markContainerRef.current.firstChild
+            );
+        }
+    };
+
+    /**
+     * Render PayPal Mark into the DOM
+     */
+    const renderPayPalMark = () => {
+        removeCurrentPayPalMark();
+        if (mark.current && markContainerRef.current) {
+            mark.current.render(markContainerRef.current).catch((err) => {
+                // component failed to render, possibly because it was closed or destroyed.
+                if (
+                    markContainerRef.current === null ||
+                    markContainerRef.current.children.length === 0
+                ) {
+                    // paypal marks container is no longer in the DOM, we can safely ignore the error
+                    return;
+                }
+                // paypal marks container is still in the DOM
+                setErrorState(() => {
+                    throw new Error(
+                        `Failed to render <PayPalMarks /> component. ${err}`
+                    );
+                });
+            });
+        }
+    };
+
     useEffect(() => {
         // verify the sdk script has successfully loaded
-        if (isResolved === false) {
-            return;
-        }
-
-        // don't rerender when already rendered
-        if (mark.current !== null) {
-            return;
-        }
+        if (isResolved === false) return;
 
         const paypalWindowNamespace = getPayPalWindowNamespace(
             options["data-namespace"]
@@ -72,30 +100,13 @@ export const PayPalMarks: FunctionComponent<PayPalMarksComponentProps> = ({
         mark.current = paypalWindowNamespace.Marks({ ...markProps });
 
         // only render the mark when eligible
-        if (mark.current.isEligible() === false) {
+        if (
+            mark.current.isEligible() === false ||
+            markContainerRef.current == null
+        )
             return;
-        }
 
-        if (markContainerRef.current === null) {
-            return;
-        }
-
-        mark.current.render(markContainerRef.current).catch((err) => {
-            // component failed to render, possibly because it was closed or destroyed.
-            if (
-                markContainerRef.current === null ||
-                markContainerRef.current.children.length === 0
-            ) {
-                // paypal marks container is no longer in the DOM, we can safely ignore the error
-                return;
-            }
-            // paypal marks container is still in the DOM
-            setErrorState(() => {
-                throw new Error(
-                    `Failed to render <PayPalMarks /> component. ${err}`
-                );
-            });
-        });
+        renderPayPalMark();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isResolved, markProps.fundingSource]);
 

--- a/src/context/scriptProviderContext.ts
+++ b/src/context/scriptProviderContext.ts
@@ -35,8 +35,7 @@ export function destroySDKScript(reactPayPalScriptID: string): void {
         `script[${SCRIPT_ID}="${reactPayPalScriptID}"]`
     );
 
-    if (scriptNode != null && scriptNode.parentNode)
-        scriptNode.parentNode.removeChild(scriptNode);
+    if (scriptNode?.parentNode) scriptNode.parentNode.removeChild(scriptNode);
 }
 
 /**


### PR DESCRIPTION
The PayPalMarks component doesn't re-render on fundingSource props changes. The component has the fundingSource as a dependency in the useEffect but was disabled because an if statement inside the useEffect hook.

With this PR we fix that problem and allows re-render the PayPalMarks component when any useEffect dependency changes.