### PR TITLE
Same signature on all the children components

### DIFF
--- a/src/components/PayPalButtons.test.js
+++ b/src/components/PayPalButtons.test.js
@@ -329,4 +329,29 @@ describe("<PayPalButtons />", () => {
         );
         spyConsoleError.mockRestore();
     });
+
+    test("should safely ignore error on render process when paypal buttons container is no longer in the DOM ", async () => {
+        const spyConsoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation();
+        const mockRender = jest
+            .fn()
+            .mockRejectedValue(new Error("Unknown error"));
+        window.paypal.Buttons = () => {
+            return {
+                close: jest.fn().mockResolvedValue(),
+                isEligible: jest.fn().mockReturnValue(true),
+                render: mockRender,
+            };
+        };
+
+        render(
+            <PayPalScriptProvider options={{ "client-id": "test" }}>
+                <PayPalButtons />
+            </PayPalScriptProvider>
+        );
+
+        await waitFor(() => expect(mockRender).toBeCalled());
+        spyConsoleError.mockRestore();
+    });
 });

--- a/src/components/PayPalButtons.test.js
+++ b/src/components/PayPalButtons.test.js
@@ -345,13 +345,16 @@ describe("<PayPalButtons />", () => {
             };
         };
 
-        render(
+        const { container } = render(
             <PayPalScriptProvider options={{ "client-id": "test" }}>
-                <PayPalButtons />
+                <PayPalButtons class="test-children" />
             </PayPalScriptProvider>
         );
 
         await waitFor(() => expect(mockRender).toBeCalled());
+        expect(
+            container.querySelector(".test-children") instanceof HTMLDivElement
+        ).toBeFalsy();
         spyConsoleError.mockRestore();
     });
 });

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -38,7 +38,7 @@ Use props for customizing your buttons. For example, here's how you would use th
 export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
     className = "",
     disabled = false,
-    children = null,
+    children,
     forceReRender = [],
     ...buttonProps
 }: PayPalButtonsComponentProps) => {
@@ -156,16 +156,18 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
         disabled ? "paypal-buttons-disabled" : ""
     }`.trim();
 
-    if (isEligible === false) {
-        return children;
-    }
-
     return (
-        <div
-            ref={buttonsContainerRef}
-            style={isDisabledStyle}
-            className={classNames}
-        />
+        <>
+            {isEligible ? (
+                <div
+                    ref={buttonsContainerRef}
+                    style={isDisabledStyle}
+                    className={classNames}
+                />
+            ) : (
+                children
+            )}
+        </>
     );
 };
 

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -6,14 +6,14 @@ import type {
     PayPalMarksComponentOptions,
     PayPalMarksComponent,
 } from "@paypal/paypal-js/types/components/marks";
-import type { PayPalProviderChildren } from "../types/scriptProviderTypes";
+import type { Children } from "../types/scriptProviderTypes";
 
 export interface PayPalMarksComponentProps extends PayPalMarksComponentOptions {
     /**
      * Pass a css class to the div container.
      */
     className?: string;
-    children?: PayPalProviderChildren;
+    children?: Children;
 }
 
 /**

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -1,12 +1,4 @@
-import React, {
-    useEffect,
-    useRef,
-    useState,
-    FunctionComponent,
-    ReactElement,
-    ReactPortal,
-    ReactFragment,
-} from "react";
+import React, { useEffect, useRef, useState, FunctionComponent } from "react";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace } from "../utils";
 import { DEFAULT_PAYPAL_NAMESPACE } from "../constants";
@@ -14,13 +6,14 @@ import type {
     PayPalMarksComponentOptions,
     PayPalMarksComponent,
 } from "@paypal/paypal-js/types/components/marks";
+import type { PayPalProviderChildren } from "../types/scriptProviderTypes";
 
 export interface PayPalMarksComponentProps extends PayPalMarksComponentOptions {
     /**
      * Pass a css class to the div container.
      */
     className?: string;
-    children?: ReactElement | ReactPortal | ReactFragment;
+    children?: PayPalProviderChildren;
 }
 
 /**

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -49,7 +49,7 @@ export const BraintreePayPalButtons: FC<BraintreePayPalButtonsComponentProps> =
     ({
         className = "",
         disabled = false,
-        children = null,
+        children,
         forceReRender = [],
         ...buttonProps
     }: BraintreePayPalButtonsComponentProps) => {

--- a/src/types/paypalButtonTypes.ts
+++ b/src/types/paypalButtonTypes.ts
@@ -1,5 +1,5 @@
-import { ReactElement } from "react";
 import type { PayPalButtonsComponentOptions } from "@paypal/paypal-js/types/components/buttons";
+import type { PayPalProviderChildren } from "../types/scriptProviderTypes";
 
 export interface PayPalButtonsComponentProps
     extends PayPalButtonsComponentOptions {
@@ -19,5 +19,5 @@ export interface PayPalButtonsComponentProps
     /**
      * Used to render custom content when ineligible.
      */
-    children?: ReactElement | null;
+    children?: PayPalProviderChildren;
 }

--- a/src/types/paypalButtonTypes.ts
+++ b/src/types/paypalButtonTypes.ts
@@ -1,5 +1,5 @@
 import type { PayPalButtonsComponentOptions } from "@paypal/paypal-js/types/components/buttons";
-import type { PayPalProviderChildren } from "../types/scriptProviderTypes";
+import type { Children } from "../types/scriptProviderTypes";
 
 export interface PayPalButtonsComponentProps
     extends PayPalButtonsComponentOptions {
@@ -19,5 +19,5 @@ export interface PayPalButtonsComponentProps
     /**
      * Used to render custom content when ineligible.
      */
-    children?: PayPalProviderChildren;
+    children?: Children;
 }

--- a/src/types/scriptProviderTypes.ts
+++ b/src/types/scriptProviderTypes.ts
@@ -1,4 +1,5 @@
 import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { ReactElement, ReactPortal, ReactFragment } from "react";
 import { SCRIPT_ID } from "../constants";
 import { BraintreePayPalCheckout } from "./braintree/paypalCheckout";
 import { DISPATCH_ACTION, SCRIPT_LOADING_STATE } from "./enums";
@@ -45,3 +46,5 @@ export interface ScriptProviderProps {
     children?: React.ReactNode;
     deferLoading?: boolean;
 }
+
+export type PayPalProviderChildren = ReactElement | ReactPortal | ReactFragment;

--- a/src/types/scriptProviderTypes.ts
+++ b/src/types/scriptProviderTypes.ts
@@ -47,4 +47,4 @@ export interface ScriptProviderProps {
     deferLoading?: boolean;
 }
 
-export type PayPalProviderChildren = ReactElement | ReactPortal | ReactFragment;
+export type Children = ReactElement | ReactPortal | ReactFragment;


### PR DESCRIPTION
In this PR we unified the children signature type on all the component [PayPalButtons, PayPalBraintreeButtons, PayPalMarks].