### PR TITLE
Storybook documentation page new structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4359,9 +4359,9 @@
             }
         },
         "@paypal/paypal-js": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-4.1.0.tgz",
-            "integrity": "sha512-fBPpNBfzIpn4hWgks+EmZmuwKopkkMRBAtvCuEkH0RQIUobH7Dtf3enyFAt1+u8ZdgdIvueSBB58lRCSP2RNkA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-4.2.0.tgz",
+            "integrity": "sha512-cLcgj2/HNHJsFIcjuOgDzjyq9OVax+1pDD5AGqVBGMVj8zl791UsnaGrEDGksrvJpHhOqVrb3XsmGL8q4yPYCA==",
             "requires": {
                 "promise-polyfill": "^8.2.0"
             }
@@ -19986,9 +19986,9 @@
             "dev": true
         },
         "promise-polyfill": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
-            "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g=="
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
+            "integrity": "sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg=="
         },
         "promise.allsettled": {
             "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     },
     "homepage": "https://paypal.github.io/react-paypal-js/",
     "dependencies": {
-        "@paypal/paypal-js": "^4.1.0",
+        "@paypal/paypal-js": "^4.2.0",
         "@paypal/sdk-constants": "^1.0.110"
     },
     "devDependencies": {

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -12,28 +12,7 @@ import type { PayPalButtonsComponentProps } from "../types";
 This `<PayPalButtons />` component renders the [Smart Payment Buttons](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#buttons).
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
 
-Use props for customizing your buttons. For example, here's how you would use the `style`, `createOrder`, and `onApprove` options:
-
-```jsx
-    import { PayPalScriptProvider, PayPalButtons } from "@paypal/react-paypal-js";
-
-    <PayPalScriptProvider options={{ "client-id": "test" }}>
-        <PayPalButtons
-            style={{ layout: "horizontal" }}
-            createOrder={(data, actions) => {
-                return actions.order.create({
-                    purchase_units: [
-                        {
-                            amount: {
-                                value: "2.00",
-                            },
-                        },
-                    ],
-                });
-            }}
-        />;
-    </PayPalScriptProvider>
-```
+Use props for customizing your buttons. Below you can find a good example on how to use `style`, `createOrder` and `onApprove`:
 */
 export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
     className = "",

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -11,8 +11,6 @@ import type { PayPalButtonsComponentProps } from "../types";
 /**
 This `<PayPalButtons />` component renders the [Smart Payment Buttons](https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-reference/#buttons).
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
-
-Use props for customizing your buttons. Below you can find a good example on how to use `style`, `createOrder` and `onApprove`:
 */
 export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
     className = "",

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -19,17 +19,9 @@ export interface PayPalMarksComponentProps extends PayPalMarksComponentOptions {
 The `<PayPalMarks />` component is used for conditionally rendering different payment options using radio buttons.
 The [Display PayPal Buttons with other Payment Methods guide](https://developer.paypal.com/docs/business/checkout/add-capabilities/buyer-experience/#display-paypal-buttons-with-other-payment-methods) describes this style of integration in detail.
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
-```jsx
-    <PayPalMarks />
-```
+
 This component can also be configured to use a single funding source similar to the [standalone buttons](https://developer.paypal.com/docs/business/checkout/configure-payments/standalone-buttons/) approach.
 A `FUNDING` object is exported by this library which has a key for every available funding source option.
-```jsx
-    import { PayPalScriptProvider, PayPalMarks, FUNDING } from "@paypal/react-paypal-js";
-    <PayPalScriptProvider options={{ "client-id": "test", components: "buttons,marks" }}>
-        <PayPalMarks fundingSource={FUNDING.PAYPAL}/>
-    </PayPalScriptProvider>
-```
 */
 export const PayPalMarks: FC<PayPalMarksComponentProps> = ({
     className = "",

--- a/src/components/PayPalMessages.tsx
+++ b/src/components/PayPalMessages.tsx
@@ -13,7 +13,12 @@ export interface PayPalMessagesComponentProps
     className?: string;
 }
 
-// FIXME: Finish documentation of this component
+/**
+This `<PayPalMessages />` messages component renders a credit messaging on upstream merchant sites.
+It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
+
+Below you can find a good example on how to use it:
+*/
 export const PayPalMessages: FunctionComponent<PayPalMessagesComponentProps> =
     ({
         className = "",

--- a/src/components/PayPalMessages.tsx
+++ b/src/components/PayPalMessages.tsx
@@ -13,6 +13,7 @@ export interface PayPalMessagesComponentProps
     className?: string;
 }
 
+// FIXME: Finish documentation of this component
 export const PayPalMessages: FunctionComponent<PayPalMessagesComponentProps> =
     ({
         className = "",

--- a/src/components/PayPalMessages.tsx
+++ b/src/components/PayPalMessages.tsx
@@ -16,8 +16,6 @@ export interface PayPalMessagesComponentProps
 /**
 This `<PayPalMessages />` messages component renders a credit messaging on upstream merchant sites.
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
-
-Below you can find a good example on how to use it:
 */
 export const PayPalMessages: FunctionComponent<PayPalMessagesComponentProps> =
     ({

--- a/src/components/PayPalScriptProvider.test.tsx
+++ b/src/components/PayPalScriptProvider.test.tsx
@@ -62,6 +62,9 @@ describe("<PayPalScriptProvider />", () => {
     });
 
     test('should set "isRejected" state to "true" after failing to load the script', async () => {
+        const spyConsoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation();
         (loadScript as jest.Mock).mockRejectedValue(new Error());
         const { state, TestComponent } = setupTestComponent();
         render(
@@ -80,9 +83,13 @@ describe("<PayPalScriptProvider />", () => {
         await waitFor(() => expect(state.isRejected).toBeTruthy());
         expect(state.isPending).toBeFalsy();
         expect(state.isResolved).toBeFalsy();
+        spyConsoleError.mockRestore();
     });
 
     test("shouldn't set isRejected state to true after failing to load the script, because the component was unmount", async () => {
+        const spyConsoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation();
         (loadScript as jest.Mock).mockRejectedValue(new Error());
         const { state, TestComponent } = setupTestComponent();
         const { unmount } = render(
@@ -99,6 +106,7 @@ describe("<PayPalScriptProvider />", () => {
         expect(state.isPending).toBeTruthy();
         expect(state.isRejected).toBeFalsy();
         expect(state.isResolved).toBeFalsy();
+        spyConsoleError.mockRestore();
     });
 
     test("should control script loading with the deferLoading prop", async () => {

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -10,15 +10,13 @@ import {
     SCRIPT_ID,
     DATA_SDK_INTEGRATION_SOURCE,
     DATA_SDK_INTEGRATION_SOURCE_VALUE,
-    ERROR_LOADING_SDK,
+    LOAD_SCRIPT_ERROR,
 } from "../constants";
 import type { ScriptProviderProps } from "../types";
 import { SCRIPT_LOADING_STATE, DISPATCH_ACTION } from "../types";
 
 /**
 This `<PayPalScriptProvider />` component handles the SDK loading process.
-The component will load the PayPal SDK library in your page transforming the internal properties into queryParams.
-That means you can set your `client-id` and the components you want to use: [buttons, messages, marks], for example.
 
 Note: You always should use this component as a wrapper for  `PayPalButtons`, `PayPalMarks`, `PayPalMessages` and `BraintreePayPalButtons` components.
  */
@@ -63,7 +61,7 @@ export const PayPalScriptProvider: FC<ScriptProviderProps> = ({
                 }
             })
             .catch((err) => {
-                console.error(ERROR_LOADING_SDK, err);
+                console.error(LOAD_SCRIPT_ERROR, err);
                 if (isSubscribed) {
                     dispatch({
                         type: DISPATCH_ACTION.LOADING_STATUS,

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -15,6 +15,13 @@ import {
 import type { ScriptProviderProps } from "../types";
 import { SCRIPT_LOADING_STATE, DISPATCH_ACTION } from "../types";
 
+/**
+This `<PayPalScriptProvider />` component handles the SDK loading process.
+The component will load the PayPal SDK library in your page transforming the internal properties into queryParams.
+That means you can set your `client-id` and the components you want to use: [buttons, messages, marks], for example.
+
+Note: You always should use this component as a wrapper for  `PayPalButtons`, `PayPalMarks`, `PayPalMessages` and `BraintreePayPalButtons` components.
+ */
 export const PayPalScriptProvider: FC<ScriptProviderProps> = ({
     options = { "client-id": "test" },
     children,

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -10,6 +10,7 @@ import {
     SCRIPT_ID,
     DATA_SDK_INTEGRATION_SOURCE,
     DATA_SDK_INTEGRATION_SOURCE_VALUE,
+    ERROR_LOADING_SDK,
 } from "../constants";
 import type { ScriptProviderProps } from "../types";
 import { SCRIPT_LOADING_STATE, DISPATCH_ACTION } from "../types";
@@ -54,7 +55,8 @@ export const PayPalScriptProvider: FC<ScriptProviderProps> = ({
                     });
                 }
             })
-            .catch(() => {
+            .catch((err) => {
+                console.error(ERROR_LOADING_SDK, err);
                 if (isSubscribed) {
                     dispatch({
                         type: DISPATCH_ACTION.LOADING_STATUS,

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -16,7 +16,8 @@ import type { ScriptProviderProps } from "../types";
 import { SCRIPT_LOADING_STATE, DISPATCH_ACTION } from "../types";
 
 /**
-This `<PayPalScriptProvider />` component handles the SDK loading process.
+This `<PayPalScriptProvider />` component takes care of loading the JS SDK `<script>`.
+It manages state for script loading so children components like `<PayPalButtons />` know when it's safe to use the `window.paypal` global namespace.
 
 Note: You always should use this component as a wrapper for  `PayPalButtons`, `PayPalMarks`, `PayPalMessages` and `BraintreePayPalButtons` components.
  */

--- a/src/components/braintree/BraintreePayPalButtons.test.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.test.tsx
@@ -16,6 +16,7 @@ import {
     EMPTY_PROVIDER_CONTEXT_CLIENT_TOKEN_ERROR_MESSAGE,
     BRAINTREE_SOURCE,
     BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
+    ERROR_LOADING_SDK,
 } from "../../constants";
 
 import { FUNDING } from "../../index";
@@ -208,8 +209,7 @@ describe("Braintree PayPal button fail in mount process", () => {
         await waitFor(() => expect(onError).toBeCalled());
         expect(onError.mock.calls[0][0]).toEqual(
             expect.objectContaining({
-                message:
-                    "An error occurred when loading the Braintree scripts: Error: Server Error",
+                message: `${ERROR_LOADING_SDK}Error: Server Error`,
             })
         );
         spyConsoleError.mockRestore();
@@ -239,8 +239,7 @@ describe("Braintree PayPal button fail in mount process", () => {
         await waitFor(() => expect(onError).toBeCalled());
         expect(onError.mock.calls[0][0]).toEqual(
             expect.objectContaining({
-                message:
-                    "An error occurred when loading the Braintree scripts: Error: Cannot create the Braintree client",
+                message: `${ERROR_LOADING_SDK}Error: Cannot create the Braintree client`,
             })
         );
         spyConsoleError.mockRestore();
@@ -268,8 +267,7 @@ describe("Braintree PayPal button fail in mount process", () => {
         await waitFor(() => expect(onError).toBeCalled());
         expect(onError.mock.calls[0][0]).toEqual(
             expect.objectContaining({
-                message:
-                    "An error occurred when loading the Braintree scripts: TypeError: Cannot read property 'client' of null",
+                message: `${ERROR_LOADING_SDK}TypeError: Cannot read property 'client' of null`,
             })
         );
         spyConsoleError.mockRestore();

--- a/src/components/braintree/BraintreePayPalButtons.test.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.test.tsx
@@ -16,7 +16,7 @@ import {
     EMPTY_PROVIDER_CONTEXT_CLIENT_TOKEN_ERROR_MESSAGE,
     BRAINTREE_SOURCE,
     BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
-    ERROR_LOADING_SDK,
+    LOAD_SCRIPT_ERROR,
 } from "../../constants";
 
 import { FUNDING } from "../../index";
@@ -209,7 +209,7 @@ describe("Braintree PayPal button fail in mount process", () => {
         await waitFor(() => expect(onError).toBeCalled());
         expect(onError.mock.calls[0][0]).toEqual(
             expect.objectContaining({
-                message: `${ERROR_LOADING_SDK}Error: Server Error`,
+                message: `${LOAD_SCRIPT_ERROR}Error: Server Error`,
             })
         );
         spyConsoleError.mockRestore();
@@ -239,7 +239,7 @@ describe("Braintree PayPal button fail in mount process", () => {
         await waitFor(() => expect(onError).toBeCalled());
         expect(onError.mock.calls[0][0]).toEqual(
             expect.objectContaining({
-                message: `${ERROR_LOADING_SDK}Error: Cannot create the Braintree client`,
+                message: `${LOAD_SCRIPT_ERROR}Error: Cannot create the Braintree client`,
             })
         );
         spyConsoleError.mockRestore();
@@ -267,7 +267,7 @@ describe("Braintree PayPal button fail in mount process", () => {
         await waitFor(() => expect(onError).toBeCalled());
         expect(onError.mock.calls[0][0]).toEqual(
             expect.objectContaining({
-                message: `${ERROR_LOADING_SDK}TypeError: Cannot read property 'client' of null`,
+                message: `${LOAD_SCRIPT_ERROR}TypeError: Cannot read property 'client' of null`,
             })
         );
         spyConsoleError.mockRestore();

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -5,7 +5,7 @@ import {
     DATA_CLIENT_TOKEN,
     BRAINTREE_SOURCE,
     BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
-    ERROR_LOADING_SDK,
+    LOAD_SCRIPT_ERROR,
 } from "../../constants";
 import { PayPalButtons } from "../PayPalButtons";
 import { useScriptProviderContext } from "../../hooks/scriptProviderHooks";
@@ -63,7 +63,7 @@ export const BraintreePayPalButtons: FC<BraintreePayPalButtonsComponentProps> =
                 })
                 .catch((err) => {
                     setErrorState(() => {
-                        throw new Error(`${ERROR_LOADING_SDK}${err}`);
+                        throw new Error(`${LOAD_SCRIPT_ERROR}${err}`);
                     });
                 });
         }, [providerContext.options, dispatch]);

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -22,32 +22,6 @@ This `<BraintreePayPalButtons />` component renders the [Braintree PayPal Button
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
 
 Use props for customizing your buttons. For example, here's how you would use the `style`, `createOrder`, and `onApprove` options:
-
-```jsx
-    import { PayPalScriptProvider, BraintreePayPalButtons } from "@paypal/react-paypal-js";
-
-    <PayPalScriptProvider options={{ "client-id": "test" }}>
-        <BraintreePayPalButtons
-            style={{ layout: "horizontal" }}
-            createOrder={(data, actions) => {
-                // the paypalCheckoutInstance from the braintree sdk integration is added to `actions.braintree`
-                return actions.braintree.createPayment({
-                    flow: "checkout",
-                    amount: "10.0",
-                    currency: "USD",
-                    intent: "capture"
-                })
-            }}
-            onApprove={(data, actions) => {
-                return actions.braintree.tokenizePayment(data)
-                    .then((payload) => {
-                        // call server-side endpoint to finish the sale
-                    })
-            }
-        />
-    </PayPalScriptProvider>
-```
-
 */
 export const BraintreePayPalButtons: FC<BraintreePayPalButtonsComponentProps> =
     ({

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -20,8 +20,6 @@ import type {
 /**
 This `<BraintreePayPalButtons />` component renders the [Braintree PayPal Buttons](https://developer.paypal.com/braintree/docs/guides/paypal/overview) for Braintree Merchants.
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
-
-Use props for customizing your buttons. For example, here's how you would use the `style`, `createOrder`, and `onApprove` options:
 */
 export const BraintreePayPalButtons: FC<BraintreePayPalButtonsComponentProps> =
     ({

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -5,6 +5,7 @@ import {
     DATA_CLIENT_TOKEN,
     BRAINTREE_SOURCE,
     BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
+    ERROR_LOADING_SDK,
 } from "../../constants";
 import { PayPalButtons } from "../PayPalButtons";
 import { useScriptProviderContext } from "../../hooks/scriptProviderHooks";
@@ -88,9 +89,7 @@ export const BraintreePayPalButtons: FC<BraintreePayPalButtonsComponentProps> =
                 })
                 .catch((err) => {
                     setErrorState(() => {
-                        throw new Error(
-                            `An error occurred when loading the Braintree scripts: ${err}`
-                        );
+                        throw new Error(`${ERROR_LOADING_SDK}${err}`);
                     });
                 });
         }, [providerContext.options, dispatch]);

--- a/src/components/hostedFields/PayPalHostedField.tsx
+++ b/src/components/hostedFields/PayPalHostedField.tsx
@@ -8,59 +8,14 @@ This `<PayPalHostedField />` component renders individual fields for [Hosted Fie
 It relies on the `<PayPalHostedFieldsProvider />` parent component for managing state related to loading the JS SDK script
 and execute some validations before the rendering the fields.
 
-Use props for customizing your hosted fields. For example, here's how you would use the `style`, `className`, `id` options:
-
-```jsx
-    import {
-        PayPalScriptProvider,
-        PayPalHostedFieldsProvider,
-        PayPalHostedField
-    } from "@paypal/react-paypal-js";
-
-    <PayPalScriptProvider options={{ "client-id": "test" }}>
-        <PayPalHostedFieldsProvider
-            createOrder={() => {
-                // Manually call your server endpoint to create the client order
-                return fetch("create_order_endpoint")
-                    .then(response => response.json())
-                    .then(order => order.id)
-                    .catch(err => {
-                        // Handle exceptions
-                    })
-            }}
-        >
-            <PayPalHostedField style={{ color: "red", border: "1px solid" }}
-                id="card-number"
-                hostedFieldType="number"
-                options={{ selector: "#card-number", placeholder: "4111 1111 1111 1111" }} />
-            <PayPalHostedField id="cvv"
-                hostedFieldType="cvv"
-                options={{ selector: "#cvv", placeholder: "CVV", maxlength: 3, maskInput: true }} />
-            <PayPalHostedField id="expiration-date"
-                hostedFieldType="expirationDate"
-                options={{ selector: "#expiration-date", placeholder: "MM/YY" }} />
-
-        </PayPalHostedFieldsProvider>
-    </PayPalScriptProvider>
-```
-
 To use the PayPal hosted fields you need to define at least three fields:
-    - A card number field
-    - The CVV code from the client card
-    - The expiration date
 
-You can define the expiration date as a single field similar to the example above, 
-or you are able to define it in two separate fields. One for the month and second for year.
-You can delete the last children component form the example above and use these: 
+- A card number field
+- The CVV code from the client card
+- The expiration date
 
-```jsx
-    <PayPalHostedField id="expiration-month"
-        hostedFieldType={PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_MONTH}
-        options={{ selector: "#expiration-month", placeholder: "MM" }} />
-    <PayPalHostedField id="expiration-year"
-        hostedFieldType={PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_YEAR}
-        options={{ selector: "#expiration-year", placeholder: "YYYY" }} />
-```
+You can define the expiration date as a single field similar to the example below, 
+or you are able to define it in [two separate fields](https://paypal.github.io/react-paypal-js//?path=/docs/paypal-paypalhostedfields--expiration-date). One for the month and second for year.
 
 Note: Take care when using multiple instances of the PayPal Hosted Fields on the same page.
 The component will fail to render when any of the selectors return more than one element.

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.test.js
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.test.js
@@ -140,7 +140,10 @@ describe("PayPalHostedFieldsProvider", () => {
         spyConsoleError.mockRestore();
     });
 
-    test("should return inmediatly when script provider is rejected", async () => {
+    test("should return immediately when script provider is rejected", async () => {
+        const spyConsoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation();
         loadScript.mockRejectedValue(new Error("Unknown error"));
 
         render(
@@ -174,6 +177,7 @@ describe("PayPalHostedFieldsProvider", () => {
         await waitFor(() => {
             expect(loadScript).toBeCalled();
         });
+        spyConsoleError.mockRestore();
     });
 
     test("should remove hostedfields components when unilegible", async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const DATA_CLIENT_TOKEN = "data-client-token";
 export const DATA_SDK_INTEGRATION_SOURCE = "data-sdk-integration-source";
 export const DATA_SDK_INTEGRATION_SOURCE_VALUE = "react-paypal-js";
 export const DATA_NAMESPACE = "data-namespace";
-export const ERROR_LOADING_SDK = "The SDK can't be loaded due";
+export const ERROR_LOADING_SDK = "The SDK can't be loaded due ";
 
 /****************************
  * Braintree error messages *

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const DATA_CLIENT_TOKEN = "data-client-token";
 export const DATA_SDK_INTEGRATION_SOURCE = "data-sdk-integration-source";
 export const DATA_SDK_INTEGRATION_SOURCE_VALUE = "react-paypal-js";
 export const DATA_NAMESPACE = "data-namespace";
-export const ERROR_LOADING_SDK = "The SDK can't be loaded due: ";
+export const ERROR_LOADING_SDK = "The SDK can't be loaded due";
 
 /****************************
  * Braintree error messages *

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const DATA_CLIENT_TOKEN = "data-client-token";
 export const DATA_SDK_INTEGRATION_SOURCE = "data-sdk-integration-source";
 export const DATA_SDK_INTEGRATION_SOURCE_VALUE = "react-paypal-js";
 export const DATA_NAMESPACE = "data-namespace";
+export const ERROR_LOADING_SDK = "The SDK can't be loaded due: ";
 
 /****************************
  * Braintree error messages *

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const DATA_CLIENT_TOKEN = "data-client-token";
 export const DATA_SDK_INTEGRATION_SOURCE = "data-sdk-integration-source";
 export const DATA_SDK_INTEGRATION_SOURCE_VALUE = "react-paypal-js";
 export const DATA_NAMESPACE = "data-namespace";
-export const ERROR_LOADING_SDK = "The SDK can't be loaded due ";
+export const LOAD_SCRIPT_ERROR = "Failed to load the PayPal JS SDK script. ";
 
 /****************************
  * Braintree error messages *

--- a/src/stories/components/CopyButton.tsx
+++ b/src/stories/components/CopyButton.tsx
@@ -1,0 +1,54 @@
+import React, { useState, ReactElement } from "react";
+import { useSandpack } from "@codesandbox/sandpack-react";
+import type { Property } from "csstype/index";
+
+const COPY_BUTTON = {
+    padding: "4px 10px",
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    color: "#333333",
+    background: "#FFFFFF",
+    fontSize: "12px",
+    lineHeight: "16px",
+    fontWeight: "700" as Property.FontWeight,
+    border: "1px solid rgba(0,0,0,.1)",
+    borderRadius: "4px 0 0 0",
+    float: "right" as Property.Float,
+    position: "relative" as Property.Position,
+    top: "-26px",
+};
+
+/**
+ * This component is use to copy the behavior from the Description component
+ * in the storybook Doc pages. It use the state of the Sandpack library
+ * to get the code inside the App.js file and write it into the clipboard
+ *
+ * @returns a ReactElement with the custom copy button
+ */
+const CopyButton = (): ReactElement => {
+    const { sandpack } = useSandpack();
+    const [isCopy, setIsCopy] = useState<boolean>(false);
+
+    const getCopyBorder = () => (isCopy ? "2px solid #1DA7FD" : "none");
+
+    const onClickHandler = () => {
+        navigator.clipboard.writeText(sandpack.files[sandpack.activePath].code);
+        setIsCopy(true);
+        // Same behavior from default Description storybook component
+        setTimeout(() => {
+            setIsCopy(false);
+        }, 1000);
+    };
+
+    return (
+        <button
+            onClick={onClickHandler}
+            style={{ ...COPY_BUTTON, borderBottom: getCopyBorder() }}
+        >
+            {isCopy ? "Copied" : "Copy"}
+        </button>
+    );
+};
+
+export default CopyButton;

--- a/src/stories/components/CustomSandpack.tsx
+++ b/src/stories/components/CustomSandpack.tsx
@@ -11,14 +11,23 @@ import type {
 } from "@codesandbox/sandpack-react/dist/types/types";
 import "@codesandbox/sandpack-react/dist/index.css";
 
+import CopyButton from "./CopyButton";
+
 // Default styles
-const customStyle = {
+const CUSTOM_STYLE = {
     width: "100%",
     height: "450px",
     border: "1px solid rgba(0,0,0,.1)",
     boxShadow: "rgb(0 0 0 / 10%) 0 1px 3px 0",
 };
 
+/**
+ * Custom component to adjust the Sandpack react library UI to the
+ * storybook requirements for a better user experience
+ *
+ * @param props to modify the UI behavior and source files
+ * @returns a ReactElement with the customized Sandpack component
+ */
 const CustomSandpack = (props: {
     template?: SandpackPredefinedTemplate;
     files?: Record<string, SandpackFile>;
@@ -31,7 +40,7 @@ const CustomSandpack = (props: {
         <SandpackThemeProvider>
             <SandpackPreview
                 customStyle={{
-                    ...customStyle,
+                    ...CUSTOM_STYLE,
                     height: props.previewHeight,
                     padding: "1em",
                     borderRadius: "4px 4px 0 0",
@@ -39,12 +48,13 @@ const CustomSandpack = (props: {
             />
             <SandpackCodeEditor
                 customStyle={{
-                    ...customStyle,
+                    ...CUSTOM_STYLE,
                     height: props.codeHeight,
                     borderRadius: "0 0 4px 4px",
                 }}
                 showLineNumbers={props.showLineNumbers || false}
             />
+            <CopyButton />
         </SandpackThemeProvider>
     </SandpackProvider>
 );

--- a/src/stories/components/DocPageStructure.tsx
+++ b/src/stories/components/DocPageStructure.tsx
@@ -14,6 +14,12 @@ import type { DocsContextProps } from "@storybook/addon-docs/dist/ts3.9/blocks";
 import CustomSandpack from "./CustomSandpack";
 import { SANDPACK_STYLES } from "../constants";
 
+/**
+ * Component to override the default DocPage structure from the storybook
+ *
+ * @param param custom props and context
+ * @returns an Element with the DocPage new structure
+ */
 const DocPageStructure = ({
     context,
     code = "",

--- a/src/stories/subscriptions/Subscriptions.stories.tsx
+++ b/src/stories/subscriptions/Subscriptions.stories.tsx
@@ -86,6 +86,18 @@ export default {
     id: "example/Subscriptions",
     title: "PayPal/Subscriptions",
     parameters: {
+        docs: {
+            description: {
+                component: `
+You can use billing plans and subscriptions to create subscriptions that process recurring PayPal payments for physical or digital goods, or services.
+A plan includes pricing and billing cycle information that defines the amount and frequency of charge for a subscription.
+You can also define a fixed plan, such as a $5 basic plan or a volume or graduated-based plan with pricing tiers based on the quantity purchased.
+
+It relies on the \`<PayPalScriptProvider />\` parent component for managing state related to loading the JS SDK script.
+For more information, see [Subscriptions](https://developer.paypal.com/docs/multiparty/subscriptions/)
+            `,
+            },
+        },
         controls: { expanded: true },
     },
     argTypes: {
@@ -100,7 +112,7 @@ export default {
                 },
             },
             description: "Change the PayPal checkout intent.",
-        }
+        },
     },
     args: {
         type: SUBSCRIPTION,
@@ -128,13 +140,12 @@ export default {
 
 const PLAN_ID = "P-3RX065706M3469222L5IFM4I";
 
-export const Default: FC<{ type: string; }> = ({
-    type,
-}) => {
+export const Default: FC<{ type: string }> = ({ type }) => {
     // Remember the type and amount props are received from the control panel
     const [_, dispatch] = usePayPalScriptReducer();
     const isSubscription = type === SUBSCRIPTION;
-    const buttonOptions = isSubscription ? buttonSubscriptionProps
+    const buttonOptions = isSubscription
+        ? buttonSubscriptionProps
         : buttonOrderProps();
     useEffect(() => {
         dispatch({
@@ -147,7 +158,7 @@ export const Default: FC<{ type: string; }> = ({
         <PayPalButtons
             forceReRender={[type]}
             {...(buttonOptions as PayPalButtonsComponentProps)}
-            style={{ label: isSubscription ? "subscribe": undefined }}
+            style={{ label: isSubscription ? "subscribe" : undefined }}
         >
             <InEligibleError />
         </PayPalButtons>
@@ -164,6 +175,6 @@ export const Default: FC<{ type: string; }> = ({
                 context={context}
                 code={getDefaultCode(context.args.type)}
             />
-        )
+        ),
     },
 };

--- a/src/stories/subscriptions/Subscriptions.stories.tsx
+++ b/src/stories/subscriptions/Subscriptions.stories.tsx
@@ -88,14 +88,12 @@ export default {
     parameters: {
         docs: {
             description: {
-                component: `
-You can use billing plans and subscriptions to create subscriptions that process recurring PayPal payments for physical or digital goods, or services.
+                component: `You can use billing plans and subscriptions to create subscriptions that process recurring PayPal payments for physical or digital goods, or services.
 A plan includes pricing and billing cycle information that defines the amount and frequency of charge for a subscription.
 You can also define a fixed plan, such as a $5 basic plan or a volume or graduated-based plan with pricing tiers based on the quantity purchased.
 
 It relies on the \`<PayPalScriptProvider />\` parent component for managing state related to loading the JS SDK script.
-For more information, see [Subscriptions](https://developer.paypal.com/docs/multiparty/subscriptions/)
-            `,
+For more information, see [Subscriptions](https://developer.paypal.com/docs/multiparty/subscriptions/)`,
             },
         },
         controls: { expanded: true },

--- a/src/stories/venmo/VenmoButton.stories.tsx
+++ b/src/stories/venmo/VenmoButton.stories.tsx
@@ -27,8 +27,7 @@ export default {
         docs: {
             source: { type: "dynamic" },
             description: {
-                component: `
-Pay with Venmo offers a simplified mobile checkout experience at no additional cost to you.
+                component: `Pay with Venmo offers a simplified mobile checkout experience at no additional cost to you.
 
 Your buyers get:
 

--- a/src/stories/venmo/VenmoButton.stories.tsx
+++ b/src/stories/venmo/VenmoButton.stories.tsx
@@ -24,7 +24,22 @@ export default {
     title: "PayPal/VenmoButton",
     parameters: {
         controls: { expanded: true },
-        docs: { source: { type: "dynamic" } },
+        docs: {
+            source: { type: "dynamic" },
+            description: {
+                component: `
+Pay with Venmo offers a simplified mobile checkout experience at no additional cost to you.
+
+Your buyers get:
+
+- A streamlined checkout process
+- Splitting and sharing of purchases.
+
+It relies on the \`<PayPalScriptProvider />\` parent component for managing state related to loading the JS SDK script.
+For more information, see [Pay with Venmo](https://developer.paypal.com/docs/business/checkout/pay-with-venmo/)
+`,
+            },
+        },
     },
     argTypes: {
         style: {
@@ -102,11 +117,10 @@ export const Default: FC<{
     );
 };
 
-
 /********************
  * OVERRIDE STORIES *
  *******************/
- (Default as Story).parameters = {
+(Default as Story).parameters = {
     docs: {
         container: ({ context }: { context: StoryContext }) => (
             <DocPageStructure

--- a/src/types/braintreePayPalButtonTypes.ts
+++ b/src/types/braintreePayPalButtonTypes.ts
@@ -31,7 +31,8 @@ export interface BraintreePayPalButtonsComponentProps
         "createOrder" | "onApprove" | "createBillingAgreement"
     > {
     /**
-     * The createOrder actions include the Braintree SDK paypalCheckoutInstance as `actions.braintree`
+     * The createOrder actions include the Braintree SDK paypalCheckoutInstance as `actions.braintree`.
+     * [createOrder docs](https://developer.paypal.com/sdk/js-sdk/reference/#createorder).
      */
     createOrder?: (
         data: Record<string, unknown>,


### PR DESCRIPTION
### Description
This PR contains a new structure to organize better the documentation page splitting the structure into three components.
- The description
- The Sandpack visualization
- The Control table to dynamically play around with components props.

:memo: Also includes descriptions for PayPalMessages, Subscriptions, Venmo, and PayPalScriptProvicer stories.

### Why are we making these changes?
:thinking: Right now is a little confusing the code examples in the documentation page, due to the duplicate code samples, one auto-generated from the source code file and the second created in the SandPack library. Please check this story: https://engineering.paypalcorp.com/jira/browse/DTPPSDK-531 for more info.

### Screenshots
👎 Current UI:
<img width="1163" alt="Screen Shot 2021-11-22 at 12 18 36 PM" src="https://user-images.githubusercontent.com/26287838/142906138-2ded260a-f36a-4e6e-affb-33771625a874.png">

:+1: Proposal:
<img width="1175" alt="Screen Shot 2021-11-22 at 12 19 42 PM" src="https://user-images.githubusercontent.com/26287838/142906232-fc061c67-afc6-4dde-9034-65d275613695.png">

As you can see in the new UI proposal will have only one block of code from the SandPack library. We get rid of the generated code block.


🧠 Please feel free to leave your comments/suggestions/ideas about these changes.