### PR TITLE
Support Braintree tokenization keys

### DIFF
--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, FunctionComponent } from "react";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
-import { DATA_NAMESPACE } from "../constants";
+import { SDK_SETTINGS } from "../constants";
 import type { PayPalButtonsComponent, OnInitActions } from "@paypal/paypal-js";
 import type { PayPalButtonsComponentProps } from "../types";
 
@@ -44,7 +44,7 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
         }
 
         const paypalWindowNamespace = getPayPalWindowNamespace(
-            options[DATA_NAMESPACE]
+            options[SDK_SETTINGS.DATA_NAMESPACE]
         );
 
         // verify dependency on window object
@@ -58,7 +58,7 @@ export const PayPalButtons: FunctionComponent<PayPalButtonsComponentProps> = ({
                         reactComponentName: PayPalButtons.displayName as string,
                         sdkComponentKey: "buttons",
                         sdkRequestedComponents: options.components,
-                        sdkDataNamespace: options[DATA_NAMESPACE],
+                        sdkDataNamespace: options[SDK_SETTINGS.DATA_NAMESPACE],
                     })
                 );
             });

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, FC, ReactNode } from "react";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
-import { DATA_NAMESPACE } from "../constants";
+import { SDK_SETTINGS } from "../constants";
 import type {
     PayPalMarksComponentOptions,
     PayPalMarksComponent,
@@ -70,7 +70,7 @@ export const PayPalMarks: FC<PayPalMarksComponentProps> = ({
         }
 
         const paypalWindowNamespace = getPayPalWindowNamespace(
-            options[DATA_NAMESPACE]
+            options[SDK_SETTINGS.DATA_NAMESPACE]
         );
 
         // verify dependency on window object
@@ -84,7 +84,7 @@ export const PayPalMarks: FC<PayPalMarksComponentProps> = ({
                         reactComponentName: PayPalMarks.displayName as string,
                         sdkComponentKey: "marks",
                         sdkRequestedComponents: options.components,
-                        sdkDataNamespace: options[DATA_NAMESPACE],
+                        sdkDataNamespace: options[SDK_SETTINGS.DATA_NAMESPACE],
                     })
                 );
             });

--- a/src/components/PayPalMessages.tsx
+++ b/src/components/PayPalMessages.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, FunctionComponent } from "react";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
-import { DATA_NAMESPACE } from "../constants";
+import { SDK_SETTINGS } from "../constants";
 import type {
     PayPalMessagesComponentOptions,
     PayPalMessagesComponent,
@@ -29,15 +29,34 @@ export const PayPalMessages: FunctionComponent<
     const messages = useRef<PayPalMessagesComponent | null>(null);
     const [, setErrorState] = useState(null);
 
-    useEffect(() => {
-        // verify the sdk script has successfully loaded
-        if (isResolved === false) {
-            return;
-        }
+        useEffect(() => {
+            // verify the sdk script has successfully loaded
+            if (isResolved === false) {
+                return;
+            }
 
-        const paypalWindowNamespace = getPayPalWindowNamespace(
-            options[DATA_NAMESPACE]
-        );
+            const paypalWindowNamespace = getPayPalWindowNamespace(
+                options[SDK_SETTINGS.DATA_NAMESPACE]
+            );
+
+            // verify dependency on window object
+            if (
+                paypalWindowNamespace === undefined ||
+                paypalWindowNamespace.Messages === undefined
+            ) {
+                return setErrorState(() => {
+                    throw new Error(
+                        generateErrorMessage({
+                            reactComponentName:
+                                PayPalMessages.displayName as string,
+                            sdkComponentKey: "messages",
+                            sdkRequestedComponents: options.components,
+                            sdkDataNamespace:
+                                options[SDK_SETTINGS.DATA_NAMESPACE],
+                        })
+                    );
+                });
+            }
 
         // verify dependency on window object
         if (
@@ -51,7 +70,7 @@ export const PayPalMessages: FunctionComponent<
                             PayPalMessages.displayName as string,
                         sdkComponentKey: "messages",
                         sdkRequestedComponents: options.components,
-                        sdkDataNamespace: options[DATA_NAMESPACE],
+                        sdkDataNamespace: options[SDK_SETTINGS.DATA_NAMESPACE],
                     })
                 );
             });

--- a/src/components/PayPalScriptProvider.test.tsx
+++ b/src/components/PayPalScriptProvider.test.tsx
@@ -1,14 +1,11 @@
 import React from "react";
 import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import { loadScript } from "@paypal/paypal-js";
+
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
-import {
-    SCRIPT_ID,
-    DATA_SDK_INTEGRATION_SOURCE,
-    DATA_SDK_INTEGRATION_SOURCE_VALUE,
-} from "../constants";
-import { PayPalScriptOptions } from "@paypal/paypal-js";
+import { SCRIPT_ID, SDK_SETTINGS } from "../constants";
+import { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),
@@ -51,7 +48,8 @@ describe("<PayPalScriptProvider />", () => {
         expect(loadScript).toHaveBeenCalledWith({
             "client-id": "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
-            [DATA_SDK_INTEGRATION_SOURCE]: DATA_SDK_INTEGRATION_SOURCE_VALUE,
+            [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
+                SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
         });
 
         // verify initial loading state
@@ -75,7 +73,8 @@ describe("<PayPalScriptProvider />", () => {
         expect(loadScript).toHaveBeenCalledWith({
             "client-id": "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
-            [DATA_SDK_INTEGRATION_SOURCE]: DATA_SDK_INTEGRATION_SOURCE_VALUE,
+            [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
+                SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
         });
 
         // verify initial loading state
@@ -138,7 +137,8 @@ describe("<PayPalScriptProvider />", () => {
         expect(loadScript).toHaveBeenCalledWith({
             "client-id": "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
-            [DATA_SDK_INTEGRATION_SOURCE]: DATA_SDK_INTEGRATION_SOURCE_VALUE,
+            [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
+                SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
         });
 
         expect(state.isPending).toBe(true);

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -6,12 +6,7 @@ import {
     ScriptContext,
     scriptReducer,
 } from "../context/scriptProviderContext";
-import {
-    SCRIPT_ID,
-    DATA_SDK_INTEGRATION_SOURCE,
-    DATA_SDK_INTEGRATION_SOURCE_VALUE,
-    LOAD_SCRIPT_ERROR,
-} from "../constants";
+import { SCRIPT_ID, SDK_SETTINGS, LOAD_SCRIPT_ERROR } from "../constants";
 import type { ScriptProviderProps } from "../types";
 import { SCRIPT_LOADING_STATE, DISPATCH_ACTION } from "../types";
 
@@ -30,7 +25,8 @@ export const PayPalScriptProvider: FC<ScriptProviderProps> = ({
         options: {
             ...options,
             [SCRIPT_ID]: `${getScriptID(options)}`,
-            [DATA_SDK_INTEGRATION_SOURCE]: DATA_SDK_INTEGRATION_SOURCE_VALUE,
+            [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
+                SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
         },
         loadingStatus: deferLoading
             ? SCRIPT_LOADING_STATE.INITIAL

--- a/src/components/braintree/BraintreePayPalButtons.test.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.test.tsx
@@ -13,7 +13,7 @@ import { PayPalButtonsComponent } from "@paypal/paypal-js";
 import { BraintreePayPalButtons } from "./BraintreePayPalButtons";
 import { PayPalScriptProvider } from "../PayPalScriptProvider";
 import {
-    EMPTY_PROVIDER_CONTEXT_CLIENT_TOKEN_ERROR_MESSAGE,
+    EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE,
     BRAINTREE_SOURCE,
     BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
     LOAD_SCRIPT_ERROR,
@@ -108,7 +108,7 @@ describe("Braintree PayPal button fail in mount process", () => {
             errorMessage = (ex as Error).message;
         }
         expect(errorMessage).toEqual(
-            "A client token wasn't found in the provider parent component"
+            EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE
         );
         expect(console.error).toHaveBeenCalled();
     });
@@ -127,7 +127,7 @@ describe("Braintree PayPal button fail in mount process", () => {
             errorMessage = (ex as Error).message;
         }
         expect(errorMessage).toEqual(
-            EMPTY_PROVIDER_CONTEXT_CLIENT_TOKEN_ERROR_MESSAGE
+            EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE
         );
         expect(console.error).toHaveBeenCalled();
     });
@@ -152,7 +152,7 @@ describe("Braintree PayPal button fail in mount process", () => {
         }
 
         expect(errorMessage).toEqual(
-            EMPTY_PROVIDER_CONTEXT_CLIENT_TOKEN_ERROR_MESSAGE
+            EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE
         );
         expect(console.error).toHaveBeenCalled();
     });

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState, useEffect } from "react";
 import { loadCustomScript } from "@paypal/paypal-js";
 
 import {
-    DATA_CLIENT_TOKEN,
+    SDK_SETTINGS,
     BRAINTREE_SOURCE,
     BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
     LOAD_SCRIPT_ERROR,
@@ -38,14 +38,17 @@ export const BraintreePayPalButtons: FC<BraintreePayPalButtonsComponentProps> =
                 loadCustomScript({ url: BRAINTREE_PAYPAL_CHECKOUT_SOURCE }),
             ])
                 .then(() => {
-                    const clientToken = providerContext.options[
-                        DATA_CLIENT_TOKEN
-                    ] as string;
+                    const clientTokenizationKey: string =
+                        providerContext.options[
+                            SDK_SETTINGS.DATA_USER_ID_TOKEN
+                        ];
+                    const clientToken: string =
+                        providerContext.options[SDK_SETTINGS.DATA_CLIENT_TOKEN];
                     const braintreeNamespace = getBraintreeWindowNamespace();
 
                     return braintreeNamespace.client
                         .create({
-                            authorization: clientToken,
+                            authorization: clientTokenizationKey || clientToken,
                         })
                         .then((clientInstance) => {
                             return braintreeNamespace.paypalCheckout.create({

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.test.js
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.test.js
@@ -7,6 +7,7 @@ import { PayPalScriptProvider } from "../PayPalScriptProvider";
 import { PayPalHostedFieldsProvider } from "./PayPalHostedFieldsProvider";
 import { PayPalHostedField } from "./PayPalHostedField";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
+import { EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE } from "../../constants";
 
 const onError = jest.fn();
 const wrapper = ({ children }) => (
@@ -65,7 +66,7 @@ describe("PayPalHostedFieldsProvider", () => {
             { wrapper }
         );
         expect(onError.mock.calls[0][0].message).toEqual(
-            "A client token wasn't found in the provider parent component"
+            EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE
         );
         spyConsoleError.mockRestore();
     });

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
 import { useScriptProviderContext } from "../../hooks/scriptProviderHooks";
-import { DATA_NAMESPACE } from "../../constants";
+import { SDK_SETTINGS } from "../../constants";
 import {
     generateHostedFieldsFromChildren,
     generateMissingHostedFieldsError,
@@ -53,14 +53,14 @@ export const PayPalHostedFieldsProvider: FC<
         }
         // Get the hosted fields from the [window.paypal.HostedFields] SDK
         hostedFields.current = getPayPalWindowNamespace(
-            options[DATA_NAMESPACE]
+            options[SDK_SETTINGS.DATA_NAMESPACE]
         ).HostedFields;
 
         if (!hostedFields.current) {
             throw new Error(
                 generateMissingHostedFieldsError({
                     components: options.components,
-                    [DATA_NAMESPACE]: options[DATA_NAMESPACE],
+                    [SDK_SETTINGS.DATA_NAMESPACE]: options[SDK_SETTINGS.DATA_NAMESPACE],
                 })
             );
         }

--- a/src/components/hostedFields/utils.test.js
+++ b/src/components/hostedFields/utils.test.js
@@ -5,7 +5,7 @@ import {
     generateMissingHostedFieldsError,
     generateHostedFieldsFromChildren,
 } from "./utils";
-import { DATA_NAMESPACE } from "../../constants";
+import { SDK_SETTINGS } from "../../constants";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
 
 const exceptionMessagePayPalNamespace =
@@ -19,7 +19,7 @@ describe("generateMissingHostedFieldsError", () => {
         expect(
             generateMissingHostedFieldsError({
                 components: "marks",
-                [DATA_NAMESPACE]: "Braintree",
+                [SDK_SETTINGS.DATA_NAMESPACE]: "Braintree",
             })
         ).toEqual(exceptionMessage);
     });

--- a/src/components/hostedFields/utils.ts
+++ b/src/components/hostedFields/utils.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PAYPAL_NAMESPACE, DATA_NAMESPACE } from "../../constants";
+import { DEFAULT_PAYPAL_NAMESPACE, SDK_SETTINGS } from "../../constants";
 
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types";
 import type {
@@ -31,7 +31,7 @@ type PayPalHostedFieldOption = {
  */
 export const generateMissingHostedFieldsError = ({
     components = "",
-    [DATA_NAMESPACE]: dataNamespace = DEFAULT_PAYPAL_NAMESPACE,
+    [SDK_SETTINGS.DATA_NAMESPACE]: dataNamespace = DEFAULT_PAYPAL_NAMESPACE,
 }: PayPalHostedFieldsNamespace): string => {
     const expectedComponents = components
         ? `${components},hosted-fields`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,17 +2,20 @@
  * Common reference to the script identifier *
  *********************************************/
 export const SCRIPT_ID = "data-react-paypal-script-id";
-export const DATA_CLIENT_TOKEN = "data-client-token";
-export const DATA_SDK_INTEGRATION_SOURCE = "data-sdk-integration-source";
-export const DATA_SDK_INTEGRATION_SOURCE_VALUE = "react-paypal-js";
-export const DATA_NAMESPACE = "data-namespace";
+export const SDK_SETTINGS = {
+    DATA_CLIENT_TOKEN: "data-client-token",
+    DATA_USER_ID_TOKEN: "data-user-id-token",
+    DATA_SDK_INTEGRATION_SOURCE: "data-sdk-integration-source",
+    DATA_SDK_INTEGRATION_SOURCE_VALUE: "react-paypal-js",
+    DATA_NAMESPACE: "data-namespace",
+};
 export const LOAD_SCRIPT_ERROR = "Failed to load the PayPal JS SDK script.";
 
 /****************************
  * Braintree error messages *
  ****************************/
-export const EMPTY_PROVIDER_CONTEXT_CLIENT_TOKEN_ERROR_MESSAGE =
-    "A client token wasn't found in the provider parent component";
+export const EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE =
+    "Invalid authorization data. Use data-client-token or data-user-id-token to authorize.";
 
 const braintreeVersion = "3.84.0";
 export const BRAINTREE_SOURCE = `https://js.braintreegateway.com/web/${braintreeVersion}/js/client.min.js`;

--- a/src/context/scriptProviderContext.ts
+++ b/src/context/scriptProviderContext.ts
@@ -1,11 +1,7 @@
 import { createContext } from "react";
 
 import { hashStr } from "../utils";
-import {
-    SCRIPT_ID,
-    DATA_SDK_INTEGRATION_SOURCE,
-    DATA_SDK_INTEGRATION_SOURCE_VALUE,
-} from "../constants";
+import { SCRIPT_ID, SDK_SETTINGS } from "../constants";
 
 import type {
     ScriptContextState,
@@ -71,8 +67,8 @@ export function scriptReducer(
                     [SCRIPT_ID]: `${getScriptID(
                         action.value as PayPalScriptOptions
                     )}`,
-                    [DATA_SDK_INTEGRATION_SOURCE]:
-                        DATA_SDK_INTEGRATION_SOURCE_VALUE,
+                    [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
+                        SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
                 },
             };
         case DISPATCH_ACTION.SET_BRAINTREE_INSTANCE:

--- a/src/hooks/contextValidator.test.ts
+++ b/src/hooks/contextValidator.test.ts
@@ -1,14 +1,17 @@
 import {
-    contextNotEmptyValidator,
-    contextOptionClientTokenNotEmptyValidator,
+    validateReducer,
+    validateBraintreeAuthorizationData,
 } from "./contextValidator";
 import { SCRIPT_LOADING_STATE } from "../types/enums";
-import { SCRIPT_ID } from "../constants";
+import {
+    SCRIPT_ID,
+    EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE,
+} from "../constants";
 
-describe("contextNotEmptyValidator", () => {
+describe("validateReducer", () => {
     test("should throw an exception when called with no args", () => {
         expect(() => {
-            contextNotEmptyValidator(null);
+            validateReducer(null);
         }).toThrowError(
             new Error(
                 "usePayPalScriptReducer must be used within a PayPalScriptProvider"
@@ -19,7 +22,7 @@ describe("contextNotEmptyValidator", () => {
     test("should throw an exception when called with an empty object", () => {
         expect(() => {
             // @ts-expect-error - improper context test
-            contextNotEmptyValidator({});
+            validateReducer({});
         }).toThrowError(
             new Error(
                 "usePayPalScriptReducer must be used within a PayPalScriptProvider"
@@ -30,7 +33,7 @@ describe("contextNotEmptyValidator", () => {
     test("should throw an exception when the dispatch function is invalid", () => {
         expect(() => {
             // @ts-expect-error - improper dispatch test
-            contextNotEmptyValidator({ dispatch: 10 });
+            validateReducer({ dispatch: 10 });
         }).toThrowError(
             new Error(
                 "usePayPalScriptReducer must be used within a PayPalScriptProvider"
@@ -41,7 +44,7 @@ describe("contextNotEmptyValidator", () => {
     test("should return an exception when dispatch is a function with empty parameters", () => {
         expect(() => {
             // @ts-expect-error - improper dispatch test
-            contextNotEmptyValidator({ dispatch: jest.fn() });
+            validateReducer({ dispatch: jest.fn() });
         }).toThrowError(
             new Error(
                 "usePayPalScriptReducer must be used within a PayPalScriptProvider"
@@ -52,20 +55,16 @@ describe("contextNotEmptyValidator", () => {
     test("should return same object if dispatch is a function with one parameter", () => {
         const state = { dispatch: jest.fn((param) => param) };
         // @ts-expect-error - improper dispatch test
-        expect(contextNotEmptyValidator(state)).toEqual(state);
+        expect(validateReducer(state)).toEqual(state);
     });
 });
 
-describe("contextOptionClientTokenNotEmptyValidator", () => {
+describe("validateBraintreeAuthorizationData", () => {
     const state = null;
     test("should throw an exception when called with no args", () => {
         expect(() => {
-            contextOptionClientTokenNotEmptyValidator(state);
-        }).toThrowError(
-            new Error(
-                "A client token wasn't found in the provider parent component"
-            )
-        );
+            validateBraintreeAuthorizationData(state);
+        }).toThrowError(new Error(EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE));
     });
 
     test("should throw an exception when data-client-token is null", () => {
@@ -79,12 +78,8 @@ describe("contextOptionClientTokenNotEmptyValidator", () => {
         };
         expect(() => {
             // @ts-expect-error - data-client-token of null not expected in types
-            contextOptionClientTokenNotEmptyValidator(state);
-        }).toThrowError(
-            new Error(
-                "A client token wasn't found in the provider parent component"
-            )
-        );
+            validateBraintreeAuthorizationData(state);
+        }).toThrowError(new Error(EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE));
     });
 
     test("should throw an exception when data-client-token is an empty string", () => {
@@ -97,12 +92,22 @@ describe("contextOptionClientTokenNotEmptyValidator", () => {
             loadingStatus: SCRIPT_LOADING_STATE.RESOLVED,
         };
         expect(() => {
-            contextOptionClientTokenNotEmptyValidator(state);
-        }).toThrowError(
-            new Error(
-                "A client token wasn't found in the provider parent component"
-            )
-        );
+            validateBraintreeAuthorizationData(state);
+        }).toThrowError(new Error(EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE));
+    });
+
+    test("should throw an exception when data-user-id-token is an empty string", () => {
+        const state = {
+            options: {
+                "data-user-id-token": "",
+                [SCRIPT_ID]: "id",
+                "client-id": "123",
+            },
+            loadingStatus: SCRIPT_LOADING_STATE.RESOLVED,
+        };
+        expect(() => {
+            validateBraintreeAuthorizationData(state);
+        }).toThrowError(new Error(EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE));
     });
 
     test("should return object if data client token is a valid string", () => {
@@ -114,6 +119,6 @@ describe("contextOptionClientTokenNotEmptyValidator", () => {
             },
             loadingStatus: SCRIPT_LOADING_STATE.RESOLVED,
         };
-        expect(contextOptionClientTokenNotEmptyValidator(state)).toEqual(state);
+        expect(validateBraintreeAuthorizationData(state)).toEqual(state);
     });
 });

--- a/src/hooks/contextValidator.ts
+++ b/src/hooks/contextValidator.ts
@@ -1,6 +1,6 @@
 import {
-    DATA_CLIENT_TOKEN,
-    EMPTY_PROVIDER_CONTEXT_CLIENT_TOKEN_ERROR_MESSAGE,
+    SDK_SETTINGS,
+    EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE,
     SCRIPT_PROVIDER_REDUCER_ERROR,
 } from "../constants";
 import type { ScriptContextState } from "../types";
@@ -11,7 +11,7 @@ import type { ScriptContextState } from "../types";
  * @param scriptContext the result of connecting to the context provider
  * @returns strict context avoiding null values in the type
  */
-export function contextNotEmptyValidator(
+export function validateReducer(
     scriptContext: ScriptContextState | null
 ): ScriptContextState {
     if (
@@ -25,18 +25,24 @@ export function contextNotEmptyValidator(
 }
 
 /**
- * Check if the data-client-token is set in the options of the context
- * This is required to create a Braintree client
+ * Check if the data-client-token or the data-user-id-token are
+ * set in the options of the context.
+ * @type data-client-token is use to pass a client token
+ * @type data-user-id-token is use to pass a client tokenization key
  *
  * @param scriptContext the result of connecting to the context provider
- * @returns strict context avoiding null values in the type and client token
+ * @throws an {@link Error} if both data-client-token and the data-user-id-token keys are null or undefine
+ * @returns strict context if one of the keys are defined
  */
-export const contextOptionClientTokenNotEmptyValidator = (
+export const validateBraintreeAuthorizationData = (
     scriptContext: ScriptContextState | null
 ): ScriptContextState => {
-    if (!scriptContext?.options?.[DATA_CLIENT_TOKEN]) {
-        throw new Error(EMPTY_PROVIDER_CONTEXT_CLIENT_TOKEN_ERROR_MESSAGE);
+    if (
+        !scriptContext?.options?.[SDK_SETTINGS.DATA_CLIENT_TOKEN] &&
+        !scriptContext?.options?.[SDK_SETTINGS.DATA_USER_ID_TOKEN]
+    ) {
+        throw new Error(EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE);
     }
 
-    return scriptContext;
+    return scriptContext as ScriptContextState;
 };

--- a/src/hooks/scriptProviderHooks.ts
+++ b/src/hooks/scriptProviderHooks.ts
@@ -2,8 +2,8 @@ import React, { useContext } from "react";
 
 import { ScriptContext } from "../context/scriptProviderContext";
 import {
-    contextNotEmptyValidator,
-    contextOptionClientTokenNotEmptyValidator,
+    validateReducer,
+    validateBraintreeAuthorizationData,
 } from "./contextValidator";
 import type {
     ScriptContextDerivedState,
@@ -23,7 +23,7 @@ export function usePayPalScriptReducer(): [
     ScriptContextDerivedState,
     React.Dispatch<ScriptReducerAction>
 ] {
-    const scriptContext = contextNotEmptyValidator(useContext(ScriptContext));
+    const scriptContext = validateReducer(useContext(ScriptContext));
 
     const derivedStatusContext = {
         ...scriptContext,
@@ -50,8 +50,8 @@ export function useScriptProviderContext(): [
     ScriptContextState,
     React.Dispatch<ScriptReducerAction>
 ] {
-    const scriptContext = contextOptionClientTokenNotEmptyValidator(
-        contextNotEmptyValidator(useContext(ScriptContext))
+    const scriptContext = validateBraintreeAuthorizationData(
+        validateReducer(useContext(ScriptContext))
     );
 
     return [

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./utils";
 import type { PayPalNamespace } from "@paypal/paypal-js";
 import type { BraintreeNamespace } from "./types";
-import { DATA_NAMESPACE } from "./constants";
+import { SDK_SETTINGS } from "./constants";
 
 describe("getPayPalWindowNamespace", () => {
     const mockPayPalNamespace = mock<PayPalNamespace>();
@@ -64,7 +64,7 @@ describe("hashStr", () => {
                     debug: false,
                     vault: false,
                     locale: "US",
-                    [DATA_NAMESPACE]: "braintree",
+                    [SDK_SETTINGS.DATA_NAMESPACE]: "braintree",
                 })
             )
         ).toMatchInlineSnapshot(


### PR DESCRIPTION
### Description
This PR supports the data-user-id-token option key on the provider, allowing the final user to set their Braintree tokenization keys. In the previous version, the BraintreePayPalButtons component only supports data-client-token, forcing the final user to make integrations using only the JWT client tokens.

### Why are we making these changes
This change allows making the Braintree integration using either the client token or the client tokenization key. Also solve this reported bug: https://github.com/paypal/react-paypal-js/issues/214. To find more info refer to this Jira ticket: https://engineering.paypalcorp.com/jira/browse/DTPPSDK-541

### Reproduction Steps
Users can integrate the Braintree as follow:

```js
<PayPalScriptProvider
    options={{
    "client-id": "your-client-id"
     "data-client-token": "your-client-token",
     // "data-user-id-token": "tokenization-key" not supported key in current version
}}>
    <BraintreePayPalButtons {...options} />
</PayPalScriptProvider>
```
With this PR the user will be able to make the Braintree integration using a JWT client token and also using their Braintree tokenization key. A validation was set to not allow a combination of both keys. Users should choose one of those keys not both in the same provider component.

Any idea/suggestion/concern is welcome 🙏.
