### PR TITLE
Braintree integration story update

### DIFF
--- a/src/components/PayPalScriptProvider.test.tsx
+++ b/src/components/PayPalScriptProvider.test.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { render, waitFor, fireEvent, screen } from "@testing-library/react";
-import { loadScript } from "@paypal/paypal-js";
-
+import { loadScript, PayPalScriptOptions } from "@paypal/paypal-js";
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { SCRIPT_ID, SDK_SETTINGS } from "../constants";
-import { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -20,6 +20,11 @@ import type {
 /**
 This `<BraintreePayPalButtons />` component renders the [Braintree PayPal Buttons](https://developer.paypal.com/braintree/docs/guides/paypal/overview) for Braintree Merchants.
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
+
+Note: You are able to make your integration using the client token or using the tokenization key.
+
+- To use the client token integration set the key `data-client-token` in the `PayPayScriptProvider` component's options.
+- To use the tokenization key integration set the key `data-user-id-token` in the `PayPayScriptProvider` component's options.
 */
 export const BraintreePayPalButtons: FC<BraintreePayPalButtonsComponentProps> =
     ({

--- a/src/stories/braintree/code.ts
+++ b/src/stories/braintree/code.ts
@@ -86,6 +86,7 @@ const getProviderStatement = (args: { intent: string; vault: boolean }) =>
 						options={{
 							"client-id": "test",
 							components: "buttons",
+							// "data-user-id-token": "your-tokenization-key-here",
 							"data-client-token": clientToken,
 							intent: "${args.intent}",
 							vault: ${args.vault},


### PR DESCRIPTION
### Description
This PR contains the needed update in order to make clear how the clients can use the Braintree integration using the client token or the tokenization key.

### Why are we making these changes?
To avoid confusion on how to integrate Braintree using the PayPal react library. Now some users are using the same key `data-client-token` to integrate using both the client-token and the tokenization-key, resulting in an error in the component because the `data-client-token` is not a JWT token and can't be decoded.

### Reproduction Steps
Set in the `PayPalSriptProvider` options a Braintree tokenization key under the `data-client-token`. The library started failing because can't decode the tokenization key string. 

### Screenshots
Previous version:
<img width="975" alt="Screen Shot 2021-12-06 at 12 44 22 PM" src="https://user-images.githubusercontent.com/26287838/144895426-3a482e33-710d-440b-b5f2-685fa71319be.png">
<img width="531" alt="Screen Shot 2021-12-06 at 12 44 35 PM" src="https://user-images.githubusercontent.com/26287838/144895435-a14f4dca-5eed-4d43-9faf-0a565662e948.png">

Update:
<img width="900" alt="Screen Shot 2021-12-06 at 12 45 15 PM" src="https://user-images.githubusercontent.com/26287838/144895540-ddceb919-7880-4108-9dde-12f6efbe6d76.png">
<img width="603" alt="Screen Shot 2021-12-06 at 12 45 30 PM" src="https://user-images.githubusercontent.com/26287838/144895554-028cce87-74fd-4d1d-b770-70f4ba985033.png">


