### PR TITLE
Replace absolute imports types from paypal-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@paypal/paypal-js": "^4.2.2",
+                "@paypal/paypal-js": "^5.0.1",
                 "@paypal/sdk-constants": "^1.0.114"
             },
             "devDependencies": {
@@ -4579,8 +4579,9 @@
             }
         },
         "node_modules/@paypal/paypal-js": {
-            "version": "4.2.2",
-            "license": "Apache-2.0",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-5.0.1.tgz",
+            "integrity": "sha512-qm17kEm/5w6B3AOx95YWFCb167OVis0/CBqDRQNQUBmDjqEe15qxk3U8LLxKeVvIyij5agx4gAyVcwkd8f6nVA==",
             "dependencies": {
                 "promise-polyfill": "^8.2.1"
             }
@@ -28676,7 +28677,9 @@
             }
         },
         "@paypal/paypal-js": {
-            "version": "4.2.2",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-5.0.1.tgz",
+            "integrity": "sha512-qm17kEm/5w6B3AOx95YWFCb167OVis0/CBqDRQNQUBmDjqEe15qxk3U8LLxKeVvIyij5agx4gAyVcwkd8f6nVA==",
             "requires": {
                 "promise-polyfill": "^8.2.1"
             }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     },
     "homepage": "https://paypal.github.io/react-paypal-js/",
     "dependencies": {
-        "@paypal/paypal-js": "^4.2.2",
+        "@paypal/paypal-js": "^5.0.1",
         "@paypal/sdk-constants": "^1.0.114"
     },
     "devDependencies": {

--- a/src/components/PayPalButtons.test.tsx
+++ b/src/components/PayPalButtons.test.tsx
@@ -13,10 +13,10 @@ import { PayPalButtons } from "./PayPalButtons";
 import { FUNDING } from "../index";
 import { loadScript, PayPalNamespace } from "@paypal/paypal-js";
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
-import {
+import type {
     PayPalButtonsComponent,
     PayPalButtonsComponentOptions,
-} from "@paypal/paypal-js/types/components/buttons";
+} from "@paypal/paypal-js";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -2,10 +2,7 @@ import React, { useEffect, useRef, useState, FunctionComponent } from "react";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
 import { DATA_NAMESPACE } from "../constants";
-import type {
-    PayPalButtonsComponent,
-    OnInitActions,
-} from "@paypal/paypal-js/types/components/buttons";
+import type { PayPalButtonsComponent, OnInitActions } from "@paypal/paypal-js";
 import type { PayPalButtonsComponentProps } from "../types";
 
 /**

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -5,7 +5,7 @@ import { DATA_NAMESPACE } from "../constants";
 import type {
     PayPalMarksComponentOptions,
     PayPalMarksComponent,
-} from "@paypal/paypal-js/types/components/marks";
+} from "@paypal/paypal-js";
 
 export interface PayPalMarksComponentProps extends PayPalMarksComponentOptions {
     /**

--- a/src/components/PayPalMessages.tsx
+++ b/src/components/PayPalMessages.tsx
@@ -5,7 +5,7 @@ import { DATA_NAMESPACE } from "../constants";
 import type {
     PayPalMessagesComponentOptions,
     PayPalMessagesComponent,
-} from "@paypal/paypal-js/types/components/messages";
+} from "@paypal/paypal-js";
 
 export interface PayPalMessagesComponentProps
     extends PayPalMessagesComponentOptions {
@@ -17,75 +17,74 @@ export interface PayPalMessagesComponentProps
 This `<PayPalMessages />` messages component renders a credit messaging on upstream merchant sites.
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
 */
-export const PayPalMessages: FunctionComponent<PayPalMessagesComponentProps> =
-    ({
-        className = "",
-        forceReRender = [],
-        ...messageProps
-    }: PayPalMessagesComponentProps) => {
-        const [{ isResolved, options }] = usePayPalScriptReducer();
-        const messagesContainerRef = useRef<HTMLDivElement>(null);
-        const messages = useRef<PayPalMessagesComponent | null>(null);
-        const [, setErrorState] = useState(null);
+export const PayPalMessages: FunctionComponent<
+    PayPalMessagesComponentProps
+> = ({
+    className = "",
+    forceReRender = [],
+    ...messageProps
+}: PayPalMessagesComponentProps) => {
+    const [{ isResolved, options }] = usePayPalScriptReducer();
+    const messagesContainerRef = useRef<HTMLDivElement>(null);
+    const messages = useRef<PayPalMessagesComponent | null>(null);
+    const [, setErrorState] = useState(null);
 
-        useEffect(() => {
-            // verify the sdk script has successfully loaded
-            if (isResolved === false) {
-                return;
-            }
+    useEffect(() => {
+        // verify the sdk script has successfully loaded
+        if (isResolved === false) {
+            return;
+        }
 
-            const paypalWindowNamespace = getPayPalWindowNamespace(
-                options[DATA_NAMESPACE]
-            );
+        const paypalWindowNamespace = getPayPalWindowNamespace(
+            options[DATA_NAMESPACE]
+        );
 
-            // verify dependency on window object
-            if (
-                paypalWindowNamespace === undefined ||
-                paypalWindowNamespace.Messages === undefined
-            ) {
-                return setErrorState(() => {
-                    throw new Error(
-                        generateErrorMessage({
-                            reactComponentName:
-                                PayPalMessages.displayName as string,
-                            sdkComponentKey: "messages",
-                            sdkRequestedComponents: options.components,
-                            sdkDataNamespace: options[DATA_NAMESPACE],
-                        })
-                    );
-                });
-            }
-
-            messages.current = paypalWindowNamespace.Messages({
-                ...messageProps,
+        // verify dependency on window object
+        if (
+            paypalWindowNamespace === undefined ||
+            paypalWindowNamespace.Messages === undefined
+        ) {
+            return setErrorState(() => {
+                throw new Error(
+                    generateErrorMessage({
+                        reactComponentName:
+                            PayPalMessages.displayName as string,
+                        sdkComponentKey: "messages",
+                        sdkRequestedComponents: options.components,
+                        sdkDataNamespace: options[DATA_NAMESPACE],
+                    })
+                );
             });
+        }
 
-            if (messagesContainerRef.current === null) {
+        messages.current = paypalWindowNamespace.Messages({
+            ...messageProps,
+        });
+
+        if (messagesContainerRef.current === null) {
+            return;
+        }
+
+        messages.current.render(messagesContainerRef.current).catch((err) => {
+            // component failed to render, possibly because it was closed or destroyed.
+            if (
+                messagesContainerRef.current === null ||
+                messagesContainerRef.current.children.length === 0
+            ) {
+                // paypal messages container is no longer in the DOM, we can safely ignore the error
                 return;
             }
+            // paypal messages container is still in the DOM
+            setErrorState(() => {
+                throw new Error(
+                    `Failed to render <PayPalMessages /> component. ${err}`
+                );
+            });
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isResolved, ...forceReRender]);
 
-            messages.current
-                .render(messagesContainerRef.current)
-                .catch((err) => {
-                    // component failed to render, possibly because it was closed or destroyed.
-                    if (
-                        messagesContainerRef.current === null ||
-                        messagesContainerRef.current.children.length === 0
-                    ) {
-                        // paypal messages container is no longer in the DOM, we can safely ignore the error
-                        return;
-                    }
-                    // paypal messages container is still in the DOM
-                    setErrorState(() => {
-                        throw new Error(
-                            `Failed to render <PayPalMessages /> component. ${err}`
-                        );
-                    });
-                });
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [isResolved, ...forceReRender]);
-
-        return <div ref={messagesContainerRef} className={className} />;
-    };
+    return <div ref={messagesContainerRef} className={className} />;
+};
 
 PayPalMessages.displayName = "PayPalMessages";

--- a/src/components/PayPalScriptProvider.test.tsx
+++ b/src/components/PayPalScriptProvider.test.tsx
@@ -8,7 +8,7 @@ import {
     DATA_SDK_INTEGRATION_SOURCE,
     DATA_SDK_INTEGRATION_SOURCE_VALUE,
 } from "../constants";
-import { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import { PayPalScriptOptions } from "@paypal/paypal-js";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),

--- a/src/components/braintree/BraintreePayPalButtons.test.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "@paypal/paypal-js";
 import { ErrorBoundary } from "react-error-boundary";
 
-import { PayPalButtonsComponent } from "@paypal/paypal-js/types/components/buttons";
+import { PayPalButtonsComponent } from "@paypal/paypal-js";
 
 import { BraintreePayPalButtons } from "./BraintreePayPalButtons";
 import { PayPalScriptProvider } from "../PayPalScriptProvider";

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
@@ -15,7 +15,7 @@ import type { PayPalHostedFieldsComponentProps } from "../../types/payPalHostedF
 import type {
     PayPalHostedFieldsComponent,
     HostedFieldsHandler,
-} from "@paypal/paypal-js/types/components/hosted-fields";
+} from "@paypal/paypal-js";
 
 /**
 This `<PayPalHostedFieldsProvider />` provider component wraps the form field elements and accepts props like `createOrder()`.

--- a/src/context/payPalHostedFieldsContext.ts
+++ b/src/context/payPalHostedFieldsContext.ts
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-import type { HostedFieldsHandler } from "@paypal/paypal-js/types/components/hosted-fields";
+import type { HostedFieldsHandler } from "@paypal/paypal-js";
 
 // Create the React context to use in the PayPal hosted fields provider
 export const PayPalHostedFieldsContext =

--- a/src/context/scriptProviderContext.ts
+++ b/src/context/scriptProviderContext.ts
@@ -14,7 +14,7 @@ import type {
 } from "../types";
 import type { BraintreePayPalCheckout } from "../types/braintree/paypalCheckout";
 import { DISPATCH_ACTION, SCRIPT_LOADING_STATE } from "../types";
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 /**
  * Generate a new random identifier for react-paypal-js

--- a/src/hooks/payPalHostedFieldsHooks.ts
+++ b/src/hooks/payPalHostedFieldsHooks.ts
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 
 import { PayPalHostedFieldsContext } from "../context/payPalHostedFieldsContext";
-import type { HostedFieldsHandler } from "@paypal/paypal-js/types/components/hosted-fields";
+import type { HostedFieldsHandler } from "@paypal/paypal-js";
 
 /**
  * Custom hook to get access to the PayPal Hosted Fields instance.

--- a/src/stories/PayPalMessages.stories.tsx
+++ b/src/stories/PayPalMessages.stories.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 

--- a/src/stories/braintree/BraintreePayPalButtons.stories.tsx
+++ b/src/stories/braintree/BraintreePayPalButtons.stories.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, ReactElement } from "react";
 import type { FC } from "react";
 
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
-import type { PayPalButtonsComponentOptions } from "@paypal/paypal-js/types/components/buttons";
+import type {
+    PayPalScriptOptions,
+    PayPalButtonsComponentOptions,
+} from "@paypal/paypal-js";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";

--- a/src/stories/constants.ts
+++ b/src/stories/constants.ts
@@ -8,6 +8,7 @@ export const ERROR = "Error";
 export const SDK = "SDK";
 export const APPROVE = "approve";
 export const SUBSCRIPTION = "subscription";
+export const ORDER_INSTANCE_ERROR = "No order instance was provided";
 
 export const CONTAINER_SIZE = {
     name: "container width",

--- a/src/stories/payPalButtons/PayPalButtons.stories.tsx
+++ b/src/stories/payPalButtons/PayPalButtons.stories.tsx
@@ -1,11 +1,10 @@
 import React, { FC, ReactElement, useEffect } from "react";
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
 import type {
+    PayPalScriptOptions,
     CreateOrderActions,
-    OnApproveData,
     OnApproveActions,
-} from "@paypal/paypal-js/types/components/buttons";
-import type { PayPalButtonsComponentOptions } from "@paypal/paypal-js/types/components/buttons";
+    PayPalButtonsComponentOptions,
+} from "@paypal/paypal-js";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 
@@ -22,6 +21,8 @@ import {
     ORDER_ID,
     CONTAINER_SIZE,
     APPROVE,
+    ERROR,
+    ORDER_INSTANCE_ERROR,
 } from "../constants";
 import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError, defaultProps } from "../commons";
@@ -195,7 +196,11 @@ export const Default: FC<StoryProps> = ({
                             return orderId;
                         });
                 }}
-                onApprove={(data: OnApproveData, actions: OnApproveActions) => {
+                onApprove={(_, actions: OnApproveActions) => {
+                    if (!actions.order) {
+                        action(ERROR)(ORDER_INSTANCE_ERROR);
+                        return Promise.reject(ORDER_INSTANCE_ERROR);
+                    }
                     return actions.order.capture().then(function (details) {
                         action(APPROVE)(details);
                     });

--- a/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
@@ -4,7 +4,7 @@ import type { FC, ReactElement } from "react";
 
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 import {
     PayPalScriptProvider,

--- a/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
@@ -3,7 +3,7 @@ import type { FC, ReactElement } from "react";
 import { action } from "@storybook/addon-actions";
 
 import type { DocsContextProps } from "@storybook/addon-docs";
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 import {
     PayPalScriptProvider,

--- a/src/stories/payPalMarks/PayPalMarks.stories.tsx
+++ b/src/stories/payPalMarks/PayPalMarks.stories.tsx
@@ -1,13 +1,13 @@
 import React, { useState, FC, ChangeEvent } from "react";
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 import type {
     CreateOrderActions,
     OnApproveData,
     OnApproveActions,
-} from "@paypal/paypal-js/types/components/buttons";
+    PayPalButtonsComponentOptions,
+} from "@paypal/paypal-js";
 import { action } from "@storybook/addon-actions";
 
-import type { PayPalButtonsComponentOptions } from "@paypal/paypal-js/types/components/buttons";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 import {
@@ -23,6 +23,8 @@ import {
     ARG_TYPE_CURRENCY,
     ORDER_ID,
     APPROVE,
+    ERROR,
+    ORDER_INSTANCE_ERROR,
 } from "../constants";
 import { InEligibleError, defaultProps } from "../commons";
 import DocPageStructure from "../components/DocPageStructure";
@@ -141,6 +143,10 @@ export const RadioButtons: FC<{
                         });
                 }}
                 onApprove={(data: OnApproveData, actions: OnApproveActions) => {
+                    if (!actions.order) {
+                        action(ERROR)(ORDER_INSTANCE_ERROR);
+                        return Promise.reject(ORDER_INSTANCE_ERROR);
+                    }
                     return actions.order.capture().then(function (details) {
                         action(APPROVE)(details);
                     });

--- a/src/stories/payPalScriptProvider/PayPalScriptProvider.stories.tsx
+++ b/src/stories/payPalScriptProvider/PayPalScriptProvider.stories.tsx
@@ -3,7 +3,7 @@ import { action } from "@storybook/addon-actions";
 
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 import { getOptionsFromQueryString } from "../utils";
 import {

--- a/src/stories/subscriptions/Subscriptions.stories.tsx
+++ b/src/stories/subscriptions/Subscriptions.stories.tsx
@@ -3,13 +3,13 @@ import { action } from "@storybook/addon-actions";
 
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
-import type { CreateSubscriptionActions } from "@paypal/paypal-js/types/components/buttons";
 import type {
+    PayPalScriptOptions,
+    CreateSubscriptionActions,
     CreateOrderActions,
     OnApproveData,
     OnApproveActions,
-} from "@paypal/paypal-js/types/components/buttons";
+} from "@paypal/paypal-js";
 
 import {
     PayPalScriptProvider,
@@ -18,7 +18,13 @@ import {
     DISPATCH_ACTION,
 } from "../../index";
 import { getOptionsFromQueryString, generateRandomString } from "../utils";
-import { ORDER_ID, APPROVE, SUBSCRIPTION } from "../constants";
+import {
+    ORDER_ID,
+    APPROVE,
+    SUBSCRIPTION,
+    ERROR,
+    ORDER_INSTANCE_ERROR,
+} from "../constants";
 import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError, defaultProps } from "../commons";
 import type { PayPalButtonsComponentProps } from "../../types/paypalButtonTypes";
@@ -69,6 +75,10 @@ const buttonOrderProps = () => ({
             });
     },
     onApprove(data: OnApproveData, actions: OnApproveActions) {
+        if (!actions.order) {
+            action(ERROR)(ORDER_INSTANCE_ERROR);
+            return Promise.reject(ORDER_INSTANCE_ERROR);
+        }
         return actions.order.capture().then(function (details) {
             action(APPROVE)(details);
         });

--- a/src/stories/venmo/VenmoButton.stories.tsx
+++ b/src/stories/venmo/VenmoButton.stories.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 

--- a/src/types/braintreePayPalButtonTypes.ts
+++ b/src/types/braintreePayPalButtonTypes.ts
@@ -1,8 +1,5 @@
 import type { PayPalButtonsComponentProps } from "./paypalButtonTypes";
-import type {
-    CreateOrderActions,
-    OnApproveActions,
-} from "@paypal/paypal-js/types/components/buttons";
+import type { CreateOrderActions, OnApproveActions } from "@paypal/paypal-js";
 import type { BraintreeClient } from "./braintree/clientTypes";
 import type {
     BraintreePayPalCheckout,

--- a/src/types/paypalButtonTypes.ts
+++ b/src/types/paypalButtonTypes.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { PayPalButtonsComponentOptions } from "@paypal/paypal-js/types/components/buttons";
+import type { PayPalButtonsComponentOptions } from "@paypal/paypal-js";
 
 export interface PayPalButtonsComponentProps
     extends PayPalButtonsComponentOptions {

--- a/src/types/scriptProviderTypes.ts
+++ b/src/types/scriptProviderTypes.ts
@@ -2,7 +2,7 @@ import { SCRIPT_ID } from "../constants";
 import { BraintreePayPalCheckout } from "./braintree/paypalCheckout";
 import { DISPATCH_ACTION, SCRIPT_LOADING_STATE } from "./enums";
 import type { ReactNode, Dispatch } from "react";
-import type { PayPalScriptOptions } from "@paypal/paypal-js/types/script-options";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 export interface ReactPayPalScriptOptions extends PayPalScriptOptions {
     [SCRIPT_ID]: string;


### PR DESCRIPTION
### Description
The PR changes the way to import types from `paypal-js`, now we can import directly from the library without need to specify the paths.

### Why are we making these changes?
To make it cleaner the way final users import types from the `paypal-js` dependency. Now we have access to all exported types from the default `index.d.ts` in the `paypal-js` library.

### Screenshots
Previous imports:
![previous](https://user-images.githubusercontent.com/26287838/149015908-507c898f-4bfe-4998-aa2d-d862b63f42fe.png)

Current imports:
![current](https://user-images.githubusercontent.com/26287838/149015934-a8699550-849c-4efc-ac36-b58810d73667.png)

