### PR TITLE
Update the way to get args from the story context

### DIFF
--- a/src/stories/PayPalMessages.stories.tsx
+++ b/src/stories/PayPalMessages.stories.tsx
@@ -98,7 +98,10 @@ export default function App() {
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getDefaultCode(context?.args?.style)}
+                code={getDefaultCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                        .style
+                )}
             />
         ),
     },

--- a/src/stories/braintree/BraintreePayPalButtons.stories.tsx
+++ b/src/stories/braintree/BraintreePayPalButtons.stories.tsx
@@ -261,7 +261,9 @@ export const BillingAgreement: FC<StoryProps> = ({
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getDefaultCode(context.args || {})}
+                code={getDefaultCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                )}
             />
         ),
     },
@@ -272,7 +274,9 @@ export const BillingAgreement: FC<StoryProps> = ({
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getBillingAgreementCode(context.args || {})}
+                code={getBillingAgreementCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                )}
             />
         ),
     },

--- a/src/stories/payPalButtons/PayPalButtons.stories.tsx
+++ b/src/stories/payPalButtons/PayPalButtons.stories.tsx
@@ -270,7 +270,9 @@ export const Donate: FC<Omit<StoryProps, "showSpinner" | "fundingSource">> = ({
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getDefaultCode(context.args || {})}
+                code={getDefaultCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                )}
             />
         ),
     },
@@ -282,7 +284,9 @@ export const Donate: FC<Omit<StoryProps, "showSpinner" | "fundingSource">> = ({
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getDonateCode(context.args || {})}
+                code={getDonateCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                )}
             />
         ),
     },

--- a/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
@@ -421,7 +421,9 @@ export const ExpirationDate: FC<{ amount: string }> = ({ amount }) => {
         }): ReactElement => (
             <DocPageStructure
                 context={context}
-                code={getDefaultCode(context.args || {})}
+                code={getDefaultCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                )}
             />
         ),
     },
@@ -436,7 +438,9 @@ export const ExpirationDate: FC<{ amount: string }> = ({ amount }) => {
         }): ReactElement => (
             <DocPageStructure
                 context={context}
-                code={getExpirationDateCode(context.args || {})}
+                code={getExpirationDateCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                )}
             />
         ),
     },

--- a/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
@@ -69,7 +69,10 @@ export default {
             }): ReactElement => (
                 <DocPageStructure
                     context={context}
-                    code={getDefaultCode(context?.args?.styles)}
+                    code={getDefaultCode(
+                        context.getStoryContext(context.storyById(context.id))
+                            .args.styles
+                    )}
                 />
             ),
         },

--- a/src/stories/payPalMarks/PayPalMarks.stories.tsx
+++ b/src/stories/payPalMarks/PayPalMarks.stories.tsx
@@ -167,7 +167,10 @@ export const RadioButtons: FC<{
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getDefaultCode(context?.args?.fundingSource)}
+                code={getDefaultCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                        .fundingSource
+                )}
             />
         ),
     },
@@ -184,7 +187,9 @@ export const RadioButtons: FC<{
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getRadioButtonsCode(context.args || {})}
+                code={getRadioButtonsCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                )}
             />
         ),
     },

--- a/src/stories/payPalScriptProvider/PayPalScriptProvider.stories.tsx
+++ b/src/stories/payPalScriptProvider/PayPalScriptProvider.stories.tsx
@@ -132,7 +132,10 @@ export const Default: FC<{ deferLoading: boolean }> = ({ deferLoading }) => {
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getDefaultCode(context?.args?.deferLoading)}
+                code={getDefaultCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                        .deferLoading
+                )}
             />
         ),
     },

--- a/src/stories/subscriptions/Subscriptions.stories.tsx
+++ b/src/stories/subscriptions/Subscriptions.stories.tsx
@@ -181,7 +181,10 @@ export const Default: FC<{ type: string }> = ({ type }) => {
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getDefaultCode(context?.args?.type)}
+                code={getDefaultCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                        .type
+                )}
             />
         ),
     },

--- a/src/stories/venmo/VenmoButton.stories.tsx
+++ b/src/stories/venmo/VenmoButton.stories.tsx
@@ -124,7 +124,10 @@ export const Default: FC<{
         container: ({ context }: { context: DocsContextProps }) => (
             <DocPageStructure
                 context={context}
-                code={getDefaultCode(context?.args?.style)}
+                code={getDefaultCode(
+                    context.getStoryContext(context.storyById(context.id)).args
+                        .style
+                )}
             />
         ),
     },


### PR DESCRIPTION
### Description
The PR updates the way to get access to the `context.args` set on the controls by default or after users' interaction.

### Why are we making these changes?
These changes are required because the `context.args` key will be deleted on version 7 of the storybook.
Meaning our stories will break in the future after we update the storybook from version 6 to version 7.

### Note
Changes are only in the story's scope not introduce any change in the behavior of the library.