### PR TITLE
fix: missing type billing agreement option on createPayment

### DIFF
--- a/src/types/braintree/paypalCheckout.ts
+++ b/src/types/braintree/paypalCheckout.ts
@@ -58,6 +58,7 @@ export interface BraintreePayPalCheckoutCreatePaymentOptions {
     billingAgreementDescription?: string | undefined;
     landingPageType?: string | undefined;
     lineItems?: BraintreeLineItem[] | undefined;
+    requestBillingAgreement?: boolean;
 }
 
 export interface BraintreePayPalCheckoutTokenizationOptions {


### PR DESCRIPTION
the property `requestBillingAgreement` is expected in order to use the **Checkout with Vault** flow:

https://developer.paypal.com/braintree/docs/guides/paypal/checkout-with-vault