### PR TITLE
Support loading Braintree from AMD modules

### DIFF
--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -1,17 +1,11 @@
 import React, { FC, useState, useEffect } from "react";
-import { loadCustomScript } from "@paypal/paypal-js";
 
-import {
-    SDK_SETTINGS,
-    BRAINTREE_SOURCE,
-    BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
-    LOAD_SCRIPT_ERROR,
-} from "../../constants";
+import { SDK_SETTINGS, LOAD_SCRIPT_ERROR } from "../../constants";
 import { PayPalButtons } from "../PayPalButtons";
 import { useScriptProviderContext } from "../../hooks/scriptProviderHooks";
-import { getBraintreeWindowNamespace } from "../../utils";
 import { decorateActions } from "./utils";
 import { DISPATCH_ACTION } from "../../types";
+import { getBraintreeLoader } from "./braintreeLoadStrategy";
 import type {
     BraintreePayPalButtonsComponentProps,
     PayPalButtonsComponentProps,
@@ -26,69 +20,64 @@ Note: You are able to make your integration using the client token or using the 
 - To use the client token integration set the key `data-client-token` in the `PayPayScriptProvider` component's options.
 - To use the tokenization key integration set the key `data-user-id-token` in the `PayPayScriptProvider` component's options.
 */
-export const BraintreePayPalButtons: FC<BraintreePayPalButtonsComponentProps> =
-    ({
-        className = "",
-        disabled = false,
-        children,
-        forceReRender = [],
-        ...buttonProps
-    }: BraintreePayPalButtonsComponentProps) => {
-        const [, setErrorState] = useState(null);
-        const [providerContext, dispatch] = useScriptProviderContext();
+export const BraintreePayPalButtons: FC<
+    BraintreePayPalButtonsComponentProps
+> = ({
+    className = "",
+    disabled = false,
+    children,
+    forceReRender = [],
+    ...buttonProps
+}: BraintreePayPalButtonsComponentProps) => {
+    const [, setErrorState] = useState(null);
+    const [providerContext, dispatch] = useScriptProviderContext();
 
-        useEffect(() => {
-            Promise.all([
-                loadCustomScript({ url: BRAINTREE_SOURCE }),
-                loadCustomScript({ url: BRAINTREE_PAYPAL_CHECKOUT_SOURCE }),
-            ])
-                .then(() => {
-                    const clientTokenizationKey: string =
-                        providerContext.options[
-                            SDK_SETTINGS.DATA_USER_ID_TOKEN
-                        ];
-                    const clientToken: string =
-                        providerContext.options[SDK_SETTINGS.DATA_CLIENT_TOKEN];
-                    const braintreeNamespace = getBraintreeWindowNamespace();
+    useEffect(() => {
+        getBraintreeLoader()
+            .then((braintreeNamespace) => {
+                const clientTokenizationKey: string =
+                    providerContext.options[SDK_SETTINGS.DATA_USER_ID_TOKEN];
+                const clientToken: string =
+                    providerContext.options[SDK_SETTINGS.DATA_CLIENT_TOKEN];
 
-                    return braintreeNamespace.client
-                        .create({
-                            authorization: clientTokenizationKey || clientToken,
-                        })
-                        .then((clientInstance) => {
-                            return braintreeNamespace.paypalCheckout.create({
-                                client: clientInstance,
-                            });
-                        })
-                        .then((paypalCheckoutInstance) => {
-                            dispatch({
-                                type: DISPATCH_ACTION.SET_BRAINTREE_INSTANCE,
-                                value: paypalCheckoutInstance,
-                            });
+                return braintreeNamespace.client
+                    .create({
+                        authorization: clientTokenizationKey || clientToken,
+                    })
+                    .then((clientInstance) => {
+                        return braintreeNamespace.paypalCheckout.create({
+                            client: clientInstance,
                         });
-                })
-                .catch((err) => {
-                    setErrorState(() => {
-                        throw new Error(`${LOAD_SCRIPT_ERROR} ${err}`);
+                    })
+                    .then((paypalCheckoutInstance) => {
+                        dispatch({
+                            type: DISPATCH_ACTION.SET_BRAINTREE_INSTANCE,
+                            value: paypalCheckoutInstance,
+                        });
                     });
+            })
+            .catch((err) => {
+                setErrorState(() => {
+                    throw new Error(`${LOAD_SCRIPT_ERROR} ${err}`);
                 });
-        }, [providerContext.options, dispatch]);
+            });
+    }, [providerContext.options, dispatch]);
 
-        return (
-            <>
-                {providerContext.braintreePayPalCheckoutInstance && (
-                    <PayPalButtons
-                        className={className}
-                        disabled={disabled}
-                        forceReRender={forceReRender}
-                        {...(decorateActions(
-                            buttonProps,
-                            providerContext.braintreePayPalCheckoutInstance
-                        ) as PayPalButtonsComponentProps)}
-                    >
-                        {children}
-                    </PayPalButtons>
-                )}
-            </>
-        );
-    };
+    return (
+        <>
+            {providerContext.braintreePayPalCheckoutInstance && (
+                <PayPalButtons
+                    className={className}
+                    disabled={disabled}
+                    forceReRender={forceReRender}
+                    {...(decorateActions(
+                        buttonProps,
+                        providerContext.braintreePayPalCheckoutInstance
+                    ) as PayPalButtonsComponentProps)}
+                >
+                    {children}
+                </PayPalButtons>
+            )}
+        </>
+    );
+};

--- a/src/components/braintree/braintreeLoadStrategy.test.ts
+++ b/src/components/braintree/braintreeLoadStrategy.test.ts
@@ -1,0 +1,89 @@
+import { BraintreePayPalCheckout } from "./../../types/braintree/paypalCheckout";
+import { BraintreeNamespace } from "./../../types/braintreePayPalButtonTypes";
+import { waitFor } from "@testing-library/react";
+import { mock } from "jest-mock-extended";
+
+import { getBraintreeLoader } from "./braintreeLoadStrategy";
+
+jest.mock("@paypal/paypal-js", () => ({
+    loadCustomScript: jest.fn(),
+}));
+
+type WindowBraintree = Window &
+    typeof global & { braintree: BraintreeNamespace };
+
+type WindowDefine = Window &
+    typeof globalThis & {
+        define: () => void;
+    } & { define: { amd: unknown } };
+
+type WindowRequire =
+    | (Window & typeof globalThis)
+    | {
+          require: (
+              dependencies: string[],
+              load: (...args: unknown[]) => void,
+              error: (err: Error) => void
+          ) => void;
+      };
+
+describe("getBraintreeLoader", () => {
+    test("should get the braintree namespace from global context", async () => {
+        const braintreeNamespace = mock<BraintreeNamespace>();
+        (window as WindowBraintree).braintree = braintreeNamespace;
+
+        waitFor(() =>
+            expect(getBraintreeLoader()).toMatchObject(braintreeNamespace)
+        );
+    });
+
+    test("should get the braintree namespace from AMD modules", async () => {
+        const braintreeNamespace = mock<BraintreeNamespace>();
+        const braintreePaypalCheckout = mock<BraintreePayPalCheckout>();
+        const defineMock = () => {
+            return;
+        };
+
+        defineMock.amd = {};
+        (window as WindowDefine).define = defineMock;
+        (window as WindowRequire).require = (
+            dependencies: string[],
+            success: (
+                braintree: BraintreeNamespace,
+                braintreeCheckout: BraintreePayPalCheckout
+            ) => void
+        ) => {
+            return success(braintreeNamespace, braintreePaypalCheckout);
+        };
+
+        waitFor(() =>
+            expect(getBraintreeLoader()).toMatchObject(braintreeNamespace)
+        );
+    });
+
+    test("should throw and error the braintree namespace from AMD modules", async () => {
+        const errorMock = new Error("Unexpected error");
+        const defineMock = () => {
+            return;
+        };
+
+        defineMock.amd = {};
+        (window as WindowDefine).define = defineMock;
+        (window as WindowRequire).require = (
+            dependencies: string[],
+            success: (
+                braintree: BraintreeNamespace,
+                braintreeCheckout: BraintreePayPalCheckout
+            ) => void,
+            error: (err: Error) => void
+        ) => {
+            return error(errorMock);
+        };
+
+        try {
+            await getBraintreeLoader();
+        } catch (err) {
+            expect(err).toBe(errorMock);
+        }
+    });
+});

--- a/src/components/braintree/braintreeLoadStrategy.ts
+++ b/src/components/braintree/braintreeLoadStrategy.ts
@@ -1,0 +1,75 @@
+import { loadCustomScript } from "@paypal/paypal-js";
+
+import { getBraintreeWindowNamespace } from "../../utils";
+import {
+    BRAINTREE_SOURCE,
+    BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
+} from "../../constants";
+
+import type { BraintreeNamespace } from "../..";
+import type { BraintreePayPalCheckout } from "./../../types/braintree/paypalCheckout";
+import type { BraintreeClient } from "./../../types/braintree/clientTypes";
+
+type WindowAMD = Window &
+    typeof globalThis & {
+        define: () => void;
+        require: (
+            dependencies: string[],
+            load: (...args: unknown[]) => void,
+            error: (err: Error) => void
+        ) => void;
+    } & { define: { amd: unknown } };
+
+/**
+ * Obtain the Braintree from the global context.
+ * The scripts are injected in the page.
+ * Creating a global namespace `window.braintree`.
+ *
+ * @since 7.5.0
+ * @returns the {@link BraintreeNamespace}
+ */
+export const getBraintreeFromGlobalContext = (): Promise<BraintreeNamespace> =>
+    Promise.all([
+        loadCustomScript({ url: BRAINTREE_SOURCE }),
+        loadCustomScript({ url: BRAINTREE_PAYPAL_CHECKOUT_SOURCE }),
+    ]).then(() => getBraintreeWindowNamespace());
+
+/**
+ * Obtain the Braintree using the AMD modules approach
+ *
+ * @since 7.5.0
+ * @returns the {@link BraintreeNamespace}
+ */
+export const getBraintreeFromAMDModule = (): Promise<BraintreeNamespace> =>
+    new Promise<BraintreeNamespace>((resolve, reject) => {
+        (window as WindowAMD).require(
+            [BRAINTREE_SOURCE, BRAINTREE_PAYPAL_CHECKOUT_SOURCE],
+            (braintree, braintreeCheckout) =>
+                resolve({
+                    client: braintree as BraintreeClient,
+                    paypalCheckout:
+                        braintreeCheckout as BraintreePayPalCheckout,
+                }),
+            (err: Error) => reject(err)
+        );
+    });
+
+/**
+ * Get the Braintree namespace using the AMD modules or getting from global context.
+ * This function enables the support for AMD modules since the Braintree scripts support it.
+ *
+ * Caveats:
+ * - Using AMD modules can introduce problems. The Braintree defines an unnamed module,
+ * meaning it can crash very easily with other [modules name](https://requirejs.org/docs/errors.html#mismatch)
+ * - The Braintree AMD modules can crash if you define a global variable `define`
+ * and you load your script manually not using the AMD APIs.
+ *
+ * @since 7.5.0
+ * @returns the {@link BraintreeNamespace}
+ */
+export const getBraintreeLoader = (): Promise<BraintreeNamespace> => {
+    return typeof (window as WindowAMD)?.define === "function" &&
+        (window as WindowAMD)?.define?.amd
+        ? getBraintreeFromAMDModule()
+        : getBraintreeFromGlobalContext();
+};


### PR DESCRIPTION
### Description
The PR contains the needed modification to load the Braintree module either way, from the global `window` context or from the AMD module library. Meaning if in the global `window` scope the keys `define` and `define.amd` are defined the Braintree won't be accessible through the global `window.braintree`. Instead will be accessible via `require` module from an AMD library.

### Why are we making these changes?
The Braintree script is supporting AMD modules, and that introduces a bug in the `react-paypal-js` repo. The main reason when this condition matches on the browser: `typeof define === "function" && define.amd` the Braintree script will be defined as an AMD module, not in the global context of the browser.
Please see this [Jira](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-630) ticket.

### Issue
This PR contains the fixes for this [issue](https://github.com/paypal/react-paypal-js/issues/215).