### PR TITLE
Enable braintreeNamespace property on the BraintreePayPalButtons component

### DIFF
--- a/src/components/braintree/utils.ts
+++ b/src/components/braintree/utils.ts
@@ -1,5 +1,33 @@
+import { loadCustomScript } from "@paypal/paypal-js";
+
+import { getBraintreeWindowNamespace } from "../../utils";
+import {
+    BRAINTREE_SOURCE,
+    BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
+} from "../../constants";
+
+import type { BraintreeNamespace } from "./../../types/braintreePayPalButtonTypes";
 import type { BraintreePayPalCheckout } from "../../types/braintree/paypalCheckout";
 import type { BraintreePayPalButtonsComponentProps } from "../../types";
+
+/**
+ * Simple check to determine if the Braintree is a valid namespace.
+ *
+ * @since 7.5.1
+ * @param braintreeSource the source {@link BraintreeNamespace}
+ * @returns a boolean representing if the namespace is valid.
+ */
+const isValidBraintreeNamespace = (braintreeSource?: BraintreeNamespace) => {
+    if (
+        typeof braintreeSource?.client?.create !== "function" &&
+        typeof braintreeSource?.paypalCheckout?.create !== "function"
+    ) {
+        throw new Error(
+            "The braintreeNamespace property is not a valid BraintreeNamespace type."
+        );
+    }
+    return true;
+};
 
 /**
  * Use `actions.braintree` to provide an interface for the paypalCheckoutInstance
@@ -41,4 +69,34 @@ export const decorateActions = (
     }
 
     return { ...buttonProps };
+};
+/**
+ * Get the Braintree namespace from the component props.
+ * If the prop `braintreeNamespace` is undefined will try to load it from the CDN.
+ * This function allows users to set the braintree manually on the `BraintreePayPalButtons` component.
+ *
+ * Use case can be for example legacy sites using AMD/UMD modules,
+ * trying to integrate the `BraintreePayPalButtons` component.
+ * If we attempt to load the Braintree from the CDN won't define the braintree namespace.
+ * This happens because the braintree script is an UMD module.
+ * After detecting the AMD on the global scope will create an anonymous module using `define`
+ * and the `BraintreePayPalButtons` won't be able to get access to the `window.braintree` namespace
+ * from the global context.
+ *
+ *
+ * @since 7.5.1
+ * @param braintreeSource the source {@link BraintreeNamespace}
+ * @returns the {@link BraintreeNamespace}
+ */
+export const getBraintreeNamespace = (
+    braintreeSource?: BraintreeNamespace
+): Promise<BraintreeNamespace> => {
+    if (braintreeSource && isValidBraintreeNamespace(braintreeSource)) {
+        return Promise.resolve(braintreeSource);
+    }
+
+    return Promise.all([
+        loadCustomScript({ url: BRAINTREE_SOURCE }),
+        loadCustomScript({ url: BRAINTREE_PAYPAL_CHECKOUT_SOURCE }),
+    ]).then(() => getBraintreeWindowNamespace());
 };

--- a/src/types/braintreePayPalButtonTypes.ts
+++ b/src/types/braintreePayPalButtonTypes.ts
@@ -49,6 +49,14 @@ export interface BraintreePayPalButtonsComponentProps
         data: OnApproveBraintreeData,
         actions: OnApproveBraintreeActions
     ) => Promise<void>;
+    /**
+     * An optional Braintree namespace.
+     * Useful to provide your own implementation of the Braintree namespace loader
+     * and avoid the default behavior of loading it from the official CDN.
+     *
+     * @since 7.5.1
+     */
+    braintreeNamespace?: BraintreeNamespace;
 }
 
 export type BraintreeNamespace = {


### PR DESCRIPTION
### Description
The PR enables a new property on the `BraintreePayPalButtons` component allowing to pass a `braintreeNamespace`. If this new property is set in the component the default behavior of loading the Braintree scripts from the CDN will be skipped and the component will trust on the `braintreeNamespace`  manually set by the consumer of the component.

### Why are we making these changes?
This change is related to this [issue](https://github.com/paypal/react-paypal-js/issues/215). If a consumer of the library is using AMD/UMD modules the Braintree scripts don't create the `window.braintree` namespace in the global context, meaning the `BraintreePayPalButtons` will fail on the render process because is not capable to get access to the global Braintree namespace. Check more in [Jira](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-630).