### PR TITLE
Enable deep find in PayPalHostedFieldsProvider

### DIFF
--- a/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, Children } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import type { FC } from "react";
 
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
@@ -7,6 +7,7 @@ import { SDK_SETTINGS } from "../../constants";
 import {
     generateHostedFieldsFromChildren,
     generateMissingHostedFieldsError,
+    deepFilterChildren,
 } from "./utils";
 import { validateHostedFieldChildren } from "./validators";
 import { SCRIPT_LOADING_STATE } from "../../types/enums";
@@ -29,7 +30,7 @@ Take a look to this link if that is the case: https://developer.paypal.com/docs/
 export const PayPalHostedFieldsProvider: FC<
     PayPalHostedFieldsComponentProps
 > = ({ styles, createOrder, notEligibleError, children }) => {
-    const childrenList = Children.toArray(children);
+    const hostedFieldChildren = deepFilterChildren(children);
     const [{ options, loadingStatus }] = useScriptProviderContext();
     const [isEligible, setIsEligible] = useState(true);
     const [cardFields, setCardFields] = useState<HostedFieldsHandler | null>(
@@ -43,7 +44,7 @@ export const PayPalHostedFieldsProvider: FC<
      * Executed on the mount process to validate the children
      */
     useEffect(() => {
-        validateHostedFieldChildren(childrenList);
+        validateHostedFieldChildren(hostedFieldChildren);
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
@@ -60,7 +61,8 @@ export const PayPalHostedFieldsProvider: FC<
             throw new Error(
                 generateMissingHostedFieldsError({
                     components: options.components,
-                    [SDK_SETTINGS.DATA_NAMESPACE]: options[SDK_SETTINGS.DATA_NAMESPACE],
+                    [SDK_SETTINGS.DATA_NAMESPACE]:
+                        options[SDK_SETTINGS.DATA_NAMESPACE],
                 })
             );
         }
@@ -77,7 +79,7 @@ export const PayPalHostedFieldsProvider: FC<
                 // Call your server to set up the transaction
                 createOrder: createOrder,
                 styles: styles,
-                fields: generateHostedFieldsFromChildren(childrenList),
+                fields: generateHostedFieldsFromChildren(hostedFieldChildren),
             })
             .then((cardFieldsInstance) => {
                 setCardFields(cardFieldsInstance);

--- a/src/components/hostedFields/utils.test.js
+++ b/src/components/hostedFields/utils.test.js
@@ -4,6 +4,7 @@ import { PayPalHostedField } from "./PayPalHostedField";
 import {
     generateMissingHostedFieldsError,
     generateHostedFieldsFromChildren,
+    deepFilterChildren,
 } from "./utils";
 import { SDK_SETTINGS } from "../../constants";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
@@ -86,5 +87,49 @@ describe("generateHostedFieldsFromChildren", () => {
                 selector: ".cvv",
             },
         });
+    });
+});
+
+describe("deepFilterChildren", () => {
+    const sourceJsx = (
+        <div>
+            <div>
+                <p>test</p>
+                <div>
+                    <PayPalHostedField hostedFieldType="number" />
+                </div>
+            </div>
+            <PayPalHostedField hostedFieldType="cvv" />
+            <div>
+                <p>test</p>
+                <div>
+                    <h5>title</h5>
+                    <p>
+                        <div>
+                            <PayPalHostedField hostedFieldType="expirationDate" />
+                        </div>
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+    test("should filter component deep", () => {
+        const result = deepFilterChildren(sourceJsx);
+
+        expect(result.length).toBe(3);
+    });
+
+    test("should filter component deeply and return provided array items", () => {
+        const result = deepFilterChildren(<div></div>, [
+            { type: "PayPalHostedField" },
+        ]);
+
+        expect(result.length).toBe(1);
+    });
+
+    test("should filter component deeply and return values by defined type name", () => {
+        const result = deepFilterChildren(sourceJsx, [], "random");
+
+        expect(result.length).toBe(0);
     });
 });

--- a/src/components/hostedFields/utils.ts
+++ b/src/components/hostedFields/utils.ts
@@ -1,3 +1,5 @@
+import { Children } from "react";
+import { PayPalHostedField } from "./PayPalHostedField";
 import { DEFAULT_PAYPAL_NAMESPACE, SDK_SETTINGS } from "../../constants";
 
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types";
@@ -13,6 +15,7 @@ import type {
     PayPalHostedFieldProps,
     PayPalHostedFieldOptions,
 } from "../../types/payPalHostedFieldTypes";
+import type { ReactNode, JSXElementConstructor } from "react";
 
 // Define the type of the fields object use in the HostedFields.render options
 type PayPalHostedFieldOption = {
@@ -81,3 +84,39 @@ export const generateHostedFieldsFromChildren = (
         }
         return fields;
     }, {});
+
+/**
+ * Search for a specific type component in a list of children components.
+ * The search will be executed recursively over all the deepness of each child in the list.
+ * This allows founding a child deeper in the JSX declaration.
+ *
+ * @since 7.5.1
+ * @param childrenList the source children list to execute teh filter process
+ * @param result       an optional array reference to add found children
+ * @param typeName     the type name criteria to make the search
+ * @returns a list with found components in the children hierarchy
+ */
+export const deepFilterChildren = (
+    children: ReactNode | ReactNode[],
+    result: (ReactChild | ReactPortal | ReactFragment)[] = [],
+    typeName: string = PayPalHostedField.name
+): (ReactChild | ReactPortal | ReactFragment)[] => {
+    Children.toArray(children).forEach((child) => {
+        if (typeof (child as ReactElement)?.props?.children === "object") {
+            deepFilterChildren(
+                (child as ReactElement).props?.children,
+                result,
+                typeName
+            );
+        }
+
+        if (
+            (child as ReactElement<PayPalHostedFieldProps, FC>)?.type?.name ===
+            typeName
+        ) {
+            result.push(child);
+        }
+    });
+
+    return result;
+};


### PR DESCRIPTION
### Description
The PR contains a solution to find all `PayPalHostedField` in the children list regardless of component depths in the `JSX` definition.

### Why are we making these changes?
Now the `PayPalHostedFieldsProvider` component not allows to wrap `PayPalHostedField` components in deeper HTMLElements. It's hard to customize the `PayPalHostedField`, it's impossible to use the component one beside the other because the final user is not able to wrapper it inside flex div.

The PR fixes this and enables to set the `PayPalHostedField` inside any complex `JSX` structure.
More information in this [Jira](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-644) ticket.

### Reproduction Steps
The following example produces an error on the validation step:

```
<PayPalHostedFieldsProvider>
    <div>
        <PayPalHostedField />
   </div>
</PayPalHostedFieldsProvider>
```

### Screenshots
<img width="897" alt="Screen Shot 2022-01-21 at 3 40 42 PM" src="https://user-images.githubusercontent.com/26287838/150597367-23cba425-e7b1-40fd-b371-3a3e0f404c4c.png">

