### PR TITLE
Migrate test files from JS to TS/TSX files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "@storybook/react": "^6.4.9",
                 "@storybook/storybook-deployer": "^2.8.10",
                 "@testing-library/react": "^12.1.2",
+                "@testing-library/react-hooks": "^7.0.2",
                 "@types/jest": "^27.4.0",
                 "@types/react": "^17.0.38",
                 "@types/react-dom": "^17.0.11",
@@ -6879,6 +6880,35 @@
                 "react-dom": "*"
             }
         },
+        "node_modules/@testing-library/react-hooks": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+            "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "@types/react": ">=16.9.0",
+                "@types/react-dom": ">=16.9.0",
+                "@types/react-test-renderer": ">=16.9.0",
+                "react-error-boundary": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "react": ">=16.9.0",
+                "react-dom": ">=16.9.0",
+                "react-test-renderer": ">=16.9.0"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-test-renderer": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
             "dev": true,
@@ -7145,6 +7175,15 @@
             "version": "11.0.5",
             "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
             "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
+            "dev": true,
+            "dependencies": {
+                "@types/react": "*"
+            }
+        },
+        "node_modules/@types/react-test-renderer": {
+            "version": "17.0.1",
+            "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+            "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
             "dev": true,
             "dependencies": {
                 "@types/react": "*"
@@ -30218,6 +30257,19 @@
                 "@testing-library/dom": "^8.0.0"
             }
         },
+        "@testing-library/react-hooks": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+            "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.12.5",
+                "@types/react": ">=16.9.0",
+                "@types/react-dom": ">=16.9.0",
+                "@types/react-test-renderer": ">=16.9.0",
+                "react-error-boundary": "^3.1.0"
+            }
+        },
         "@tootallnate/once": {
             "version": "1.1.2",
             "dev": true
@@ -30457,6 +30509,15 @@
             "version": "11.0.5",
             "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
             "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
+        "@types/react-test-renderer": {
+            "version": "17.0.1",
+            "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+            "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
             "dev": true,
             "requires": {
                 "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "@storybook/react": "^6.4.9",
         "@storybook/storybook-deployer": "^2.8.10",
         "@testing-library/react": "^12.1.2",
+        "@testing-library/react-hooks": "^7.0.2",
         "@types/jest": "^27.4.0",
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",

--- a/src/components/PayPalMarks.test.tsx
+++ b/src/components/PayPalMarks.test.tsx
@@ -95,6 +95,8 @@ describe("<PayPalMarks />", () => {
         const spyConsoleError = jest
             .spyOn(console, "error")
             .mockImplementation();
+        (window.paypal as PayPalNamespace).Marks = undefined;
+
         render(
             <PayPalScriptProvider
                 options={{

--- a/src/components/__snapshots__/PayPalMarks.test.tsx.snap
+++ b/src/components/__snapshots__/PayPalMarks.test.tsx.snap
@@ -4,6 +4,10 @@ exports[`<PayPalMarks /> should catch and throw unexpected zoid render errors 1`
 
 exports[`<PayPalMarks /> should throw an error when no components are passed to the PayPalScriptProvider 1`] = `"Cannot read properties of undefined (reading 'isEligible')"`;
 
-exports[`<PayPalMarks /> should throw an error when the 'marks' component is in the components list but wasn't load in the paypal object 1`] = `"Cannot read properties of undefined (reading 'isEligible')"`;
+exports[`<PayPalMarks /> should throw an error when the 'marks' component is in the components list but wasn't load in the paypal object 1`] = `"Unable to render <PayPalMarks /> because window.paypal.Marks is undefined."`;
 
-exports[`<PayPalMarks /> should throw an error when the 'marks' component is missing from the components list passed to the PayPalScriptProvider 1`] = `"Cannot read properties of undefined (reading 'isEligible')"`;
+exports[`<PayPalMarks /> should throw an error when the 'marks' component is missing from the components list passed to the PayPalScriptProvider 1`] = `
+"Unable to render <PayPalMarks /> because window.paypal.Marks is undefined.
+To fix the issue, add 'marks' to the list of components passed to the parent PayPalScriptProvider:
+\`<PayPalScriptProvider options={{ components: 'buttons,messages,marks'}}>\`."
+`;

--- a/src/components/hostedFields/PayPalHostedField.test.tsx
+++ b/src/components/hostedFields/PayPalHostedField.test.tsx
@@ -6,14 +6,23 @@ import { PayPalHostedField } from "./PayPalHostedField";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
 
+import type { ReactNode, ProviderProps } from "react";
+import type { PayPalHostedFieldContext } from "../../types";
+
 const onError = jest.fn();
-const wrapper = ({ children }) => (
+const wrapper = ({ children }: { children: ReactNode }) => (
     <ErrorBoundary fallback={<div>Error</div>} onError={onError}>
         {children}
     </ErrorBoundary>
 );
 
-const providerRender = (ui, { providerProps, ...renderOptions }) => {
+const providerRender = (
+    ui: ReactNode,
+    {
+        providerProps,
+        ...renderOptions
+    }: { providerProps: ProviderProps<PayPalHostedFieldContext> }
+) => {
     return render(
         <PayPalHostedFieldsContext.Provider {...providerProps}>
             {ui}
@@ -56,8 +65,8 @@ describe("PayPalHostedField", () => {
         );
         const renderedElement = container.querySelector(".class1");
 
-        expect(renderedElement.classList.contains("class2")).toBeTruthy();
-        expect(renderedElement.classList.contains("class3")).toBeTruthy();
+        expect(renderedElement?.classList.contains("class2")).toBeTruthy();
+        expect(renderedElement?.classList.contains("class3")).toBeTruthy();
     });
 
     test("should render component with specific style", () => {
@@ -73,10 +82,11 @@ describe("PayPalHostedField", () => {
             />,
             defaultProviderValue
         );
-        const renderedElement = container.querySelector(".number");
+        const renderedElement =
+            container.querySelector<HTMLDivElement>(".number");
 
-        expect(renderedElement.style.color).toEqual("black");
-        expect(renderedElement.style.border).toEqual("1px solid");
+        expect(renderedElement?.style.color).toEqual("black");
+        expect(renderedElement?.style.border).toEqual("1px solid");
     });
 
     test("should fail rendering the component when context is invalid", async () => {

--- a/src/components/hostedFields/utils.test.ts
+++ b/src/components/hostedFields/utils.test.ts
@@ -24,13 +24,13 @@ describe("generateMissingHostedFieldsError", () => {
     });
 
     test("should throw exception with default namespace", () => {
-        expect(generateMissingHostedFieldsError({})).toEqual(
+        expect(generateMissingHostedFieldsError({ components: "" })).toEqual(
             exceptionMessagePayPalNamespace
         );
     });
 
     test("should throw exception unknown exception ", () => {
-        window.paypal = {};
+        window.paypal = { version: "" };
 
         expect(
             generateMissingHostedFieldsError({ components: "hosted-fields" })
@@ -82,8 +82,8 @@ describe("validateHostedFieldChildren", () => {
                 PAYPAL_HOSTED_FIELDS_TYPES.NUMBER,
                 PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_DATE,
                 PAYPAL_HOSTED_FIELDS_TYPES.CVV,
-                "custom_1",
-                "custom_2",
+                "custom_1" as PAYPAL_HOSTED_FIELDS_TYPES,
+                "custom_2" as PAYPAL_HOSTED_FIELDS_TYPES,
             ]);
         }).not.toThrow();
     });

--- a/src/hooks/payPalHostedFieldsHooks.test.ts
+++ b/src/hooks/payPalHostedFieldsHooks.test.ts
@@ -1,0 +1,11 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import { usePayPalHostedFields } from "./payPalHostedFieldsHooks";
+
+describe("usePayPalHostedFields", () => {
+    test("should return context", () => {
+        const { result } = renderHook(() => usePayPalHostedFields());
+
+        expect(result.current).toMatchObject({});
+    });
+});


### PR DESCRIPTION
### Description
The PR contains the needed changes to migrate from `js` test files to `ts` or `tsx` files. Also contains some enhancement in the test coverage per file.

### Why are we making these changes?
To standardize the test files extension and use typescript files over native javascript files.
Related ticket [JIRA](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-647).

### Dependent Changes 
The PR depends on this [PR](https://github.com/paypal/react-paypal-js/pull/240), because some breaking changes were introduced, meaning the unit test changed as well.