### PR TITLE
chore: use semver for validating node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
                 "babel-jest": "^27.4.6",
                 "babel-loader": "^8.2.3",
                 "chalk": "^4.1.2",
-                "check-node-version": "^4.2.1",
                 "eslint": "^8.6.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-react": "^7.28.0",
@@ -62,6 +61,7 @@
                 "rollup": "^2.63.0",
                 "rollup-plugin-cleanup": "^3.2.1",
                 "rollup-plugin-terser": "^7.0.2",
+                "semver": "^7.3.5",
                 "standard-version": "^9.3.2",
                 "string-template": "^1.0.0",
                 "typescript": "^4.5.4"
@@ -205,6 +205,15 @@
                 "node": ">=4"
             }
         },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/core/node_modules/supports-color": {
             "version": "5.5.0",
             "dev": true,
@@ -329,6 +338,15 @@
                 "@babel/core": "^7.0.0"
             }
         },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/helper-create-class-features-plugin": {
             "version": "7.16.7",
             "dev": true,
@@ -380,6 +398,15 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0-0"
+            }
+        },
+        "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
@@ -2282,6 +2309,15 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/preset-env/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/preset-flow": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.16.7.tgz",
@@ -3007,20 +3043,6 @@
             },
             "engines": {
                 "node": ">=v12"
-            }
-        },
-        "node_modules/@commitlint/is-ignored/node_modules/semver": {
-            "version": "7.3.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@commitlint/lint": {
@@ -4539,21 +4561,6 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16"
             }
         },
-        "node_modules/@npmcli/fs/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@npmcli/move-file": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
@@ -5588,6 +5595,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@storybook/builder-webpack4/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@storybook/channel-postmessage": {
             "version": "6.4.9",
             "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.4.9.tgz",
@@ -5888,6 +5904,15 @@
                 "@babel/core": "^7.4.0-0"
             }
         },
+        "node_modules/@storybook/core-common/node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@storybook/core-common/node_modules/@types/node": {
             "version": "14.18.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
@@ -5991,21 +6016,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@storybook/core-common/node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@storybook/core-common/node_modules/fs-extra": {
@@ -6586,6 +6596,15 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@storybook/react-docgen-typescript-plugin/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@storybook/router": {
@@ -7346,20 +7365,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-            "version": "7.3.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/experimental-utils": {
             "version": "5.9.0",
             "dev": true,
@@ -7498,20 +7503,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.3.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
@@ -8511,6 +8502,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/babel-loader/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/babel-plugin-add-react-displayname": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
@@ -8657,6 +8657,15 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
@@ -9544,37 +9553,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/check-node-version": {
-            "version": "4.2.1",
-            "dev": true,
-            "license": "Unlicense",
-            "dependencies": {
-                "chalk": "^3.0.0",
-                "map-values": "^1.0.1",
-                "minimist": "^1.2.0",
-                "object-filter": "^1.0.2",
-                "run-parallel": "^1.1.4",
-                "semver": "^6.3.0"
-            },
-            "bin": {
-                "check-node-version": "bin.js"
-            },
-            "engines": {
-                "node": ">=8.3.0"
-            }
-        },
-        "node_modules/check-node-version/node_modules/chalk": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/chokidar": {
             "version": "3.5.2",
             "dev": true,
@@ -10431,6 +10409,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/conventional-changelog-writer/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/conventional-commits-filter": {
             "version": "2.0.7",
             "dev": true,
@@ -10674,6 +10661,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cp-file/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/cpy": {
@@ -11124,6 +11120,15 @@
             },
             "engines": {
                 "node": ">=4.0.0"
+            }
+        },
+        "node_modules/css-loader/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/css-select": {
@@ -12386,6 +12391,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/eslint-plugin-react/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/eslint-scope": {
             "version": "4.0.3",
             "dev": true,
@@ -12545,20 +12559,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/eslint/node_modules/semver": {
-            "version": "7.3.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/eslint/node_modules/strip-ansi": {
@@ -14132,6 +14132,15 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/git-semver-tags/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/git-up": {
@@ -15723,6 +15732,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/istanbul-lib-instrument/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/istanbul-lib-report": {
             "version": "3.0.0",
             "dev": true,
@@ -15748,6 +15766,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/istanbul-lib-report/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/istanbul-lib-source-maps": {
@@ -17227,20 +17254,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.3.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/jest-snapshot/node_modules/source-map": {
             "version": "0.6.1",
             "dev": true,
@@ -18213,11 +18226,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/map-values": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "Public Domain"
-        },
         "node_modules/map-visit": {
             "version": "1.0.0",
             "dev": true,
@@ -18945,20 +18953,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/normalize-package-data/node_modules/semver": {
-            "version": "7.3.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "dev": true,
@@ -19081,11 +19075,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/object-filter": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/object-inspect": {
             "version": "1.10.3",
@@ -19974,21 +19963,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/postcss-loader/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/postcss-modules-extract-imports": {
@@ -22063,11 +22037,18 @@
             }
         },
         "node_modules/semver": {
-            "version": "6.3.0",
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
             "dev": true,
-            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
             "bin": {
                 "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/send": {
@@ -22819,20 +22800,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/standard-version/node_modules/semver": {
-            "version": "7.3.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/standard-version/node_modules/supports-color": {
             "version": "5.5.0",
             "dev": true,
@@ -23554,6 +23521,15 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
@@ -25702,6 +25678,12 @@
                     "version": "3.0.0",
                     "dev": true
                 },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
                 "supports-color": {
                     "version": "5.5.0",
                     "dev": true,
@@ -25785,6 +25767,14 @@
                 "@babel/helper-validator-option": "^7.16.7",
                 "browserslist": "^4.17.5",
                 "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-create-class-features-plugin": {
@@ -25820,6 +25810,14 @@
                 "lodash.debounce": "^4.0.8",
                 "resolve": "^1.14.2",
                 "semver": "^6.1.2"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-environment-visitor": {
@@ -26995,6 +26993,12 @@
                         "@babel/helper-validator-identifier": "^7.16.7",
                         "to-fast-properties": "^2.0.0"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -27546,15 +27550,6 @@
             "requires": {
                 "@commitlint/types": "^16.0.0",
                 "semver": "7.3.5"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@commitlint/lint": {
@@ -28684,17 +28679,6 @@
             "requires": {
                 "@gar/promisify": "^1.0.1",
                 "semver": "^7.3.5"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@npmcli/move-file": {
@@ -29315,6 +29299,12 @@
                     "requires": {
                         "p-limit": "^3.0.2"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -29536,6 +29526,14 @@
                         "lodash.debounce": "^4.0.8",
                         "resolve": "^1.14.2",
                         "semver": "^6.1.2"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "6.3.0",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                            "dev": true
+                        }
                     }
                 },
                 "@types/node": {
@@ -29607,15 +29605,6 @@
                                 "parse-json": "^5.0.0",
                                 "path-type": "^4.0.0",
                                 "yaml": "^1.7.2"
-                            }
-                        },
-                        "semver": {
-                            "version": "7.3.5",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                            "dev": true,
-                            "requires": {
-                                "lru-cache": "^6.0.0"
                             }
                         }
                     }
@@ -30038,6 +30027,12 @@
                     "requires": {
                         "find-up": "^4.0.0"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -30646,15 +30641,6 @@
                 "regexpp": "^3.2.0",
                 "semver": "^7.3.5",
                 "tsutils": "^3.21.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/experimental-utils": {
@@ -30721,15 +30707,6 @@
                 "is-glob": "^4.0.3",
                 "semver": "^7.3.5",
                 "tsutils": "^3.21.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/visitor-keys": {
@@ -31443,6 +31420,12 @@
                     "requires": {
                         "find-up": "^4.0.0"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -31565,6 +31548,14 @@
                 "@babel/compat-data": "^7.13.11",
                 "@babel/helper-define-polyfill-provider": "^0.3.0",
                 "semver": "^6.1.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "babel-plugin-polyfill-corejs3": {
@@ -32183,28 +32174,6 @@
             "version": "1.1.4",
             "dev": true
         },
-        "check-node-version": {
-            "version": "4.2.1",
-            "dev": true,
-            "requires": {
-                "chalk": "^3.0.0",
-                "map-values": "^1.0.1",
-                "minimist": "^1.2.0",
-                "object-filter": "^1.0.2",
-                "run-parallel": "^1.1.4",
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "3.0.0",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
-            }
-        },
         "chokidar": {
             "version": "3.5.2",
             "dev": true,
@@ -32805,6 +32774,14 @@
                 "semver": "^6.0.0",
                 "split": "^1.0.0",
                 "through2": "^4.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "conventional-commits-filter": {
@@ -32977,6 +32954,12 @@
                     "requires": {
                         "semver": "^6.0.0"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -33344,6 +33327,12 @@
                         "emojis-list": "^3.0.0",
                         "json5": "^1.0.1"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -34292,13 +34281,6 @@
                     "version": "1.2.1",
                     "dev": true
                 },
-                "semver": {
-                    "version": "7.3.5",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "strip-ansi": {
                     "version": "6.0.1",
                     "dev": true,
@@ -34362,6 +34344,12 @@
                         "is-core-module": "^2.2.0",
                         "path-parse": "^1.0.6"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -35536,6 +35524,14 @@
             "requires": {
                 "meow": "^8.0.0",
                 "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "git-up": {
@@ -36574,6 +36570,14 @@
                 "@istanbuljs/schema": "^0.1.2",
                 "istanbul-lib-coverage": "^3.2.0",
                 "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "istanbul-lib-report": {
@@ -36591,6 +36595,12 @@
                     "requires": {
                         "semver": "^6.0.0"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 }
             }
         },
@@ -37774,13 +37784,6 @@
                         }
                     }
                 },
-                "semver": {
-                    "version": "7.3.5",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "source-map": {
                     "version": "0.6.1",
                     "dev": true
@@ -38359,10 +38362,6 @@
             "version": "1.5.0",
             "dev": true
         },
-        "map-values": {
-            "version": "1.0.1",
-            "dev": true
-        },
         "map-visit": {
             "version": "1.0.0",
             "dev": true,
@@ -38917,13 +38916,6 @@
                     "requires": {
                         "has": "^1.0.3"
                     }
-                },
-                "semver": {
-                    "version": "7.3.5",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
                 }
             }
         },
@@ -39013,10 +39005,6 @@
                     }
                 }
             }
-        },
-        "object-filter": {
-            "version": "1.0.2",
-            "dev": true
         },
         "object-inspect": {
             "version": "1.10.3",
@@ -39642,15 +39630,6 @@
                         "@types/json-schema": "^7.0.8",
                         "ajv": "^6.12.5",
                         "ajv-keywords": "^3.5.2"
-                    }
-                },
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
                     }
                 }
             }
@@ -41125,8 +41104,13 @@
             }
         },
         "semver": {
-            "version": "6.3.0",
-            "dev": true
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "send": {
             "version": "0.17.2",
@@ -41675,13 +41659,6 @@
                         "p-limit": "^3.0.2"
                     }
                 },
-                "semver": {
-                    "version": "7.3.5",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "supports-color": {
                     "version": "5.5.0",
                     "dev": true,
@@ -42191,6 +42168,12 @@
                         "ajv": "^6.12.5",
                         "ajv-keywords": "^3.5.2"
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
                 },
                 "serialize-javascript": {
                     "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
         "babel-jest": "^27.4.6",
         "babel-loader": "^8.2.3",
         "chalk": "^4.1.2",
-        "check-node-version": "^4.2.1",
         "eslint": "^8.6.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-react": "^7.28.0",
@@ -98,6 +97,7 @@
         "rollup": "^2.63.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-terser": "^7.0.2",
+        "semver": "^7.3.5",
         "standard-version": "^9.3.2",
         "string-template": "^1.0.0",
         "typescript": "^4.5.4"

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,69 +1,26 @@
 const { readFileSync } = require("fs");
 const { join } = require("path");
 const chalk = require("chalk");
-const check = require("check-node-version");
+const semver = require("semver");
 
-const nodeVersion = readFileSync(join(__dirname, "../", ".nvmrc"), "utf-8");
+const expectedNodeVersion = readFileSync(
+    join(__dirname, "../", ".nvmrc"),
+    "utf-8"
+);
+const isValidNodeVersion = semver.satisfies(
+    process.version,
+    expectedNodeVersion
+);
 
-check({ node: nodeVersion }, (err, result) => {
-    if (err) {
-        throw err;
-    }
-
-    printVersions(result);
-    process.exit(result.isSatisfied ? 0 : 1);
-});
-
-// printVersions and printInstalledVersion were copied from:
-// https://github.com/parshap/check-node-version/blob/master/cli.js
-
-function printVersions(result) {
-    Object.keys(result.versions).forEach((name) => {
-        const info = result.versions[name];
-        const isSatisfied = info.isSatisfied;
-
-        // print installed version
-        if (!isSatisfied) {
-            printInstalledVersion(name, info);
-        }
-
-        if (isSatisfied) return;
-
-        // report any non-compliant versions
-        const { raw, range } = info.wanted;
-
-        console.error(
-            chalk.red(
-                `Wanted ${name} version ` + chalk.bold(`${raw} (${range})`)
-            ),
-            "\n"
-        );
-    });
+// successfully exit when Node version is valid
+if (isValidNodeVersion) {
+    return;
 }
 
-function printInstalledVersion(
-    name,
-    { version, isSatisfied, invalid, notfound }
-) {
-    let versionNote = "";
+const output = `
+node: ${chalk.bold(process.version)}
+Wanted node version ${chalk.bold(expectedNodeVersion)}
+`;
 
-    if (version) {
-        versionNote = name + ": " + chalk.bold(version);
-    }
-
-    if (invalid) {
-        versionNote =
-            name + ": " + chalk.bold("given version not semver-compliant");
-    }
-
-    if (notfound) {
-        versionNote = name + ": not found";
-    }
-
-    if (isSatisfied) {
-        if (version) console.log(versionNote);
-        else console.log(chalk.gray(versionNote));
-    } else {
-        console.log(chalk.red(versionNote));
-    }
-}
+console.error(chalk.red(output));
+process.exit(1);


### PR DESCRIPTION
Remove the `node-check-version` dependency and replace it with using `process.version` and the `semver` library directly.

Same as https://github.com/paypal/paypal-js/pull/155