### PR TITLE
Chore: Tweak the imports organizations and duplicates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint"],
+    "plugins": ["@typescript-eslint", "import"],
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
@@ -30,7 +30,21 @@
         "react/prop-types": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "curly": "warn",
-        "eqeqeq": "warn"
+        "eqeqeq": "warn",
+        "import/order": [
+            1,
+            {
+                "groups": [
+                    "external",
+                    "builtin",
+                    ["internal", "sibling", "parent"],
+                    "index",
+                    "type",
+                    "object"
+                ],
+                "newlines-between": "always"
+            }
+        ]
     },
     "overrides": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
                 "chalk": "^4.1.2",
                 "eslint": "^8.8.0",
                 "eslint-config-prettier": "^8.3.0",
+                "eslint-plugin-import": "^2.25.4",
                 "eslint-plugin-react": "^7.28.0",
                 "eslint-plugin-react-hooks": "^4.3.0",
                 "husky": "^7.0.4",
@@ -6608,6 +6609,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/json5": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+            "dev": true
+        },
         "node_modules/@types/mdast": {
             "version": "3.0.10",
             "dev": true,
@@ -11833,6 +11840,168 @@
                 "eslint": ">=7.0.0"
             }
         },
+        "node_modules/eslint-import-resolver-node": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+            "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^3.2.7",
+                "resolve": "^1.20.0"
+            }
+        },
+        "node_modules/eslint-import-resolver-node/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/eslint-module-utils": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+            "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^3.2.7",
+                "find-up": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/eslint-module-utils/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/eslint-module-utils/node_modules/find-up": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/eslint-module-utils/node_modules/locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/eslint-module-utils/node_modules/p-limit": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
+            "dependencies": {
+                "p-try": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/eslint-module-utils/node_modules/p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/eslint-module-utils/node_modules/p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/eslint-module-utils/node_modules/path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/eslint-plugin-import": {
+            "version": "2.25.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
+            "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+            "dev": true,
+            "dependencies": {
+                "array-includes": "^3.1.4",
+                "array.prototype.flat": "^1.2.5",
+                "debug": "^2.6.9",
+                "doctrine": "^2.1.0",
+                "eslint-import-resolver-node": "^0.3.6",
+                "eslint-module-utils": "^2.7.2",
+                "has": "^1.0.3",
+                "is-core-module": "^2.8.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "^3.0.4",
+                "object.values": "^1.1.5",
+                "resolve": "^1.20.0",
+                "tsconfig-paths": "^3.12.0"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "peerDependencies": {
+                "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+            }
+        },
+        "node_modules/eslint-plugin-import/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-import/node_modules/doctrine": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "dev": true,
+            "dependencies": {
+                "esutils": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/eslint-plugin-import/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
         "node_modules/eslint-plugin-react": {
             "version": "7.28.0",
             "dev": true,
@@ -14790,9 +14959,10 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.4.0",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has": "^1.0.3"
             },
@@ -23407,6 +23577,39 @@
                 }
             }
         },
+        "node_modules/tsconfig-paths": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+            "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+            "dev": true,
+            "dependencies": {
+                "@types/json5": "^0.0.29",
+                "json5": "^1.0.1",
+                "minimist": "^1.2.0",
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "node_modules/tsconfig-paths/node_modules/json5": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.0"
+            },
+            "bin": {
+                "json5": "lib/cli.js"
+            }
+        },
+        "node_modules/tsconfig-paths/node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/tslib": {
             "version": "2.3.1",
             "dev": true,
@@ -29616,6 +29819,12 @@
             "version": "7.0.9",
             "dev": true
         },
+        "@types/json5": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+            "dev": true
+        },
         "@types/mdast": {
             "version": "3.0.10",
             "dev": true,
@@ -33527,6 +33736,144 @@
             "dev": true,
             "requires": {}
         },
+        "eslint-import-resolver-node": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+            "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.2.7",
+                "resolve": "^1.20.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "eslint-module-utils": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+            "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.2.7",
+                "find-up": "^2.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-import": {
+            "version": "2.25.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
+            "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+            "dev": true,
+            "requires": {
+                "array-includes": "^3.1.4",
+                "array.prototype.flat": "^1.2.5",
+                "debug": "^2.6.9",
+                "doctrine": "^2.1.0",
+                "eslint-import-resolver-node": "^0.3.6",
+                "eslint-module-utils": "^2.7.2",
+                "has": "^1.0.3",
+                "is-core-module": "^2.8.0",
+                "is-glob": "^4.0.3",
+                "minimatch": "^3.0.4",
+                "object.values": "^1.1.5",
+                "resolve": "^1.20.0",
+                "tsconfig-paths": "^3.12.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "doctrine": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
         "eslint-plugin-react": {
             "version": "7.28.0",
             "dev": true,
@@ -35536,7 +35883,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.4.0",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -41647,6 +41996,35 @@
             "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
             "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
             "dev": true
+        },
+        "tsconfig-paths": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+            "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+            "dev": true,
+            "requires": {
+                "@types/json5": "^0.0.29",
+                "json5": "^1.0.1",
+                "minimist": "^1.2.0",
+                "strip-bom": "^3.0.0"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
+            }
         },
         "tslib": {
             "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "chalk": "^4.1.2",
         "eslint": "^8.8.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
         "husky": "^7.0.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import { terser } from "rollup-plugin-terser";
 import cleanup from "rollup-plugin-cleanup";
+
 import pkg from "./package.json";
 
 const pkgName = pkg.name.split("@paypal/")[1];

--- a/src/components/PayPalButtons.test.tsx
+++ b/src/components/PayPalButtons.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { useState, type ReactNode } from "react";
 import {
     render,
     waitFor,
@@ -8,15 +8,16 @@ import {
 } from "@testing-library/react";
 import { ErrorBoundary } from "react-error-boundary";
 import { mock } from "jest-mock-extended";
+import {
+    loadScript,
+    PayPalNamespace,
+    type PayPalButtonsComponent,
+    type PayPalButtonsComponentOptions,
+} from "@paypal/paypal-js";
 
 import { PayPalButtons } from "./PayPalButtons";
-import { FUNDING } from "../index";
-import { loadScript, PayPalNamespace } from "@paypal/paypal-js";
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
-import type {
-    PayPalButtonsComponent,
-    PayPalButtonsComponentOptions,
-} from "@paypal/paypal-js";
+import { FUNDING } from "../index";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -1,7 +1,14 @@
-import React, { useEffect, useRef, useState, FunctionComponent } from "react";
+import React, {
+    useEffect,
+    useRef,
+    useState,
+    type FunctionComponent,
+} from "react";
+
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
 import { SDK_SETTINGS } from "../constants";
+
 import type { PayPalButtonsComponent, OnInitActions } from "@paypal/paypal-js";
 import type { PayPalButtonsComponentProps } from "../types";
 

--- a/src/components/PayPalMarks.test.tsx
+++ b/src/components/PayPalMarks.test.tsx
@@ -1,11 +1,12 @@
-import React, { ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import { render, waitFor } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
+import { loadScript, PayPalNamespace } from "@paypal/paypal-js";
+import { ErrorBoundary } from "react-error-boundary";
+
 import { PayPalScriptProvider } from "../components/PayPalScriptProvider";
 import { PayPalMarks } from "./PayPalMarks";
 import { FUNDING } from "../index";
-import { loadScript, PayPalNamespace } from "@paypal/paypal-js";
-import { ErrorBoundary } from "react-error-boundary";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -1,7 +1,15 @@
-import React, { useEffect, useRef, useState, FC, ReactNode } from "react";
+import React, {
+    useEffect,
+    useRef,
+    useState,
+    type FC,
+    type ReactNode,
+} from "react";
+
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
 import { SDK_SETTINGS } from "../constants";
+
 import type {
     PayPalMarksComponentOptions,
     PayPalMarksComponent,

--- a/src/components/PayPalMessages.test.tsx
+++ b/src/components/PayPalMessages.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import { render, waitFor } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
 import { loadScript, PayPalNamespace } from "@paypal/paypal-js";

--- a/src/components/PayPalMessages.tsx
+++ b/src/components/PayPalMessages.tsx
@@ -1,7 +1,14 @@
-import React, { useEffect, useRef, useState, FunctionComponent } from "react";
+import React, {
+    useEffect,
+    useRef,
+    useState,
+    type FunctionComponent,
+} from "react";
+
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
 import { SDK_SETTINGS } from "../constants";
+
 import type {
     PayPalMessagesComponentOptions,
     PayPalMessagesComponent,

--- a/src/components/PayPalScriptProvider.test.tsx
+++ b/src/components/PayPalScriptProvider.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import { loadScript, PayPalScriptOptions } from "@paypal/paypal-js";
+
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { SCRIPT_ID, SDK_SETTINGS } from "../constants";

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useReducer } from "react";
+import React, { useEffect, useReducer, type FC } from "react";
 import { loadScript } from "@paypal/paypal-js";
 
 import {
@@ -7,8 +7,11 @@ import {
     scriptReducer,
 } from "../context/scriptProviderContext";
 import { SCRIPT_ID, SDK_SETTINGS, LOAD_SCRIPT_ERROR } from "../constants";
-import type { ScriptProviderProps } from "../types";
-import { SCRIPT_LOADING_STATE, DISPATCH_ACTION } from "../types";
+import {
+    SCRIPT_LOADING_STATE,
+    DISPATCH_ACTION,
+    type ScriptProviderProps,
+} from "../types";
 
 /**
 This `<PayPalScriptProvider />` component takes care of loading the JS SDK `<script>`.

--- a/src/components/braintree/BraintreePayPalButtons.test.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.test.tsx
@@ -5,10 +5,9 @@ import {
     loadScript,
     loadCustomScript,
     PayPalNamespace,
+    PayPalButtonsComponent,
 } from "@paypal/paypal-js";
 import { ErrorBoundary } from "react-error-boundary";
-
-import { PayPalButtonsComponent } from "@paypal/paypal-js";
 
 import { BraintreePayPalButtons } from "./BraintreePayPalButtons";
 import { PayPalScriptProvider } from "../PayPalScriptProvider";
@@ -18,7 +17,6 @@ import {
     BRAINTREE_PAYPAL_CHECKOUT_SOURCE,
     LOAD_SCRIPT_ERROR,
 } from "../../constants";
-
 import { FUNDING } from "../../index";
 
 jest.mock("@paypal/paypal-js", () => ({

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -1,13 +1,13 @@
-import React, { FC, useState, useEffect } from "react";
+import React, { useState, useEffect, type FC } from "react";
 
 import { SDK_SETTINGS, LOAD_SCRIPT_ERROR } from "../../constants";
 import { PayPalButtons } from "../PayPalButtons";
 import { useScriptProviderContext } from "../../hooks/scriptProviderHooks";
 import { decorateActions, getBraintreeNamespace } from "./utils";
-import { DISPATCH_ACTION } from "../../types";
-import type {
-    BraintreePayPalButtonsComponentProps,
-    PayPalButtonsComponentProps,
+import {
+    DISPATCH_ACTION,
+    type BraintreePayPalButtonsComponentProps,
+    type PayPalButtonsComponentProps,
 } from "../../types";
 
 /**

--- a/src/components/braintree/utils.test.ts
+++ b/src/components/braintree/utils.test.ts
@@ -1,12 +1,12 @@
 import { mock } from "jest-mock-extended";
 
 import { decorateActions, getBraintreeNamespace } from "./utils";
-import { BraintreePayPalCheckout } from "../../types/braintree/paypalCheckout";
-import { CreateBillingAgreementActions } from "../..";
 import { getBraintreeWindowNamespace } from "../../utils";
 
-import type { BraintreeNamespace } from "./../../types/braintreePayPalButtonTypes";
+import type { BraintreePayPalCheckout } from "../../types/braintree/paypalCheckout";
+import type { CreateBillingAgreementActions } from "../..";
 import type {
+    BraintreeNamespace,
     CreateOrderBraintreeActions,
     OnApproveBraintreeActions,
     OnApproveBraintreeData,

--- a/src/components/hostedFields/PayPalHostedField.test.tsx
+++ b/src/components/hostedFields/PayPalHostedField.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { type ReactNode, type ProviderProps } from "react";
 import { render, waitFor } from "@testing-library/react";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -6,7 +6,6 @@ import { PayPalHostedField } from "./PayPalHostedField";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
 
-import type { ReactNode, ProviderProps } from "react";
 import type { PayPalHostedFieldContext } from "../../types";
 
 const onError = jest.fn();

--- a/src/components/hostedFields/PayPalHostedField.tsx
+++ b/src/components/hostedFields/PayPalHostedField.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, type FC } from "react";
+
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
 
-import type { FC } from "react";
 import type { PayPalHostedFieldProps } from "../../types/payPalHostedFieldTypes";
 
 /**

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.test.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { type ReactNode } from "react";
 import { render, waitFor } from "@testing-library/react";
 import { ErrorBoundary } from "react-error-boundary";
 import { loadScript } from "@paypal/paypal-js";
@@ -10,7 +10,6 @@ import { PayPalHostedField } from "./PayPalHostedField";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
 import { EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE } from "../../constants";
 
-import type { ReactNode } from "react";
 import type {
     PayPalNamespace,
     PayPalHostedFieldsComponent,

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useRef } from "react";
-import type { FC } from "react";
+import React, { useState, useEffect, useRef, type FC } from "react";
 
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
+import { useHostedFieldsRegister } from "./hooks";
 import { useScriptProviderContext } from "../../hooks/scriptProviderHooks";
 import { SDK_SETTINGS } from "../../constants";
 import {
@@ -13,7 +13,6 @@ import {
     SCRIPT_LOADING_STATE,
 } from "../../types/enums";
 import { getPayPalWindowNamespace } from "../../utils";
-import { useHostedFieldsRegister } from "./hooks";
 
 import type { PayPalHostedFieldsComponentProps } from "../../types/payPalHostedFieldTypes";
 import type {

--- a/src/components/hostedFields/hooks.ts
+++ b/src/components/hostedFields/hooks.ts
@@ -1,4 +1,4 @@
-import { useRef, MutableRefObject } from "react";
+import { useRef, type MutableRefObject } from "react";
 
 import type { PayPalHostedFieldsRegistered } from "../../types/payPalHostedFieldTypes";
 

--- a/src/components/hostedFields/utils.test.ts
+++ b/src/components/hostedFields/utils.test.ts
@@ -1,11 +1,13 @@
-import { generateMissingHostedFieldsError } from "./utils";
 import {
     SDK_SETTINGS,
     HOSTED_FIELDS_CHILDREN_ERROR,
     HOSTED_FIELDS_DUPLICATE_CHILDREN_ERROR,
 } from "../../constants";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
-import { validateHostedFieldChildren } from "./utils";
+import {
+    validateHostedFieldChildren,
+    generateMissingHostedFieldsError,
+} from "./utils";
 
 const exceptionMessagePayPalNamespace =
     "Unable to render <PayPalHostedFieldsProvider /> because window.paypal.HostedFields is undefined.\nTo fix the issue, add 'hosted-fields' to the list of components passed to the parent PayPalScriptProvider: <PayPalScriptProvider options={{ components: 'hosted-fields'}}>";

--- a/src/context/scriptProviderContext.ts
+++ b/src/context/scriptProviderContext.ts
@@ -2,15 +2,16 @@ import { createContext } from "react";
 
 import { hashStr } from "../utils";
 import { SCRIPT_ID, SDK_SETTINGS } from "../constants";
-
-import type {
-    ScriptContextState,
-    ReactPayPalScriptOptions,
-    ScriptReducerAction,
+import {
+    DISPATCH_ACTION,
+    SCRIPT_LOADING_STATE,
+    type ScriptContextState,
+    type ReactPayPalScriptOptions,
+    type ScriptReducerAction,
 } from "../types";
-import type { BraintreePayPalCheckout } from "../types/braintree/paypalCheckout";
-import { DISPATCH_ACTION, SCRIPT_LOADING_STATE } from "../types";
+
 import type { PayPalScriptOptions } from "@paypal/paypal-js";
+import type { BraintreePayPalCheckout } from "../types/braintree/paypalCheckout";
 
 /**
  * Generate a new random identifier for react-paypal-js

--- a/src/hooks/contextValidator.ts
+++ b/src/hooks/contextValidator.ts
@@ -3,6 +3,7 @@ import {
     EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE,
     SCRIPT_PROVIDER_REDUCER_ERROR,
 } from "../constants";
+
 import type { ScriptContextState } from "../types";
 
 /**

--- a/src/hooks/payPalHostedFieldsHooks.ts
+++ b/src/hooks/payPalHostedFieldsHooks.ts
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
 import { PayPalHostedFieldsContext } from "../context/payPalHostedFieldsContext";
+
 import type { PayPalHostedFieldContext } from "../types";
 
 /**

--- a/src/hooks/scriptProviderHooks.ts
+++ b/src/hooks/scriptProviderHooks.ts
@@ -5,12 +5,12 @@ import {
     validateReducer,
     validateBraintreeAuthorizationData,
 } from "./contextValidator";
-import type {
-    ScriptContextDerivedState,
-    ScriptContextState,
-    ScriptReducerAction,
+import {
+    SCRIPT_LOADING_STATE,
+    type ScriptContextDerivedState,
+    type ScriptContextState,
+    type ScriptReducerAction,
 } from "../types";
-import { SCRIPT_LOADING_STATE } from "../types";
 
 /**
  * Custom hook to get access to the Script context and

--- a/src/stories/PayPalMessages.stories.tsx
+++ b/src/stories/PayPalMessages.stories.tsx
@@ -1,13 +1,13 @@
-import React, { FC } from "react";
-
-import type { PayPalScriptOptions } from "@paypal/paypal-js";
-import type { StoryFn } from "@storybook/react";
-import type { DocsContextProps } from "@storybook/addon-docs";
+import React, { type FC } from "react";
 
 import { PayPalScriptProvider, PayPalMessages } from "../index";
 import DocPageStructure from "./components/DocPageStructure";
 import { getOptionsFromQueryString } from "./utils";
 import { COMPONENT_PROPS_CATEGORY } from "./constants";
+
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
+import type { StoryFn } from "@storybook/react";
+import type { DocsContextProps } from "@storybook/addon-docs";
 
 const scriptProviderOptions: PayPalScriptOptions = {
     "client-id": "test",

--- a/src/stories/braintree/BraintreePayPalButtons.stories.tsx
+++ b/src/stories/braintree/BraintreePayPalButtons.stories.tsx
@@ -1,18 +1,5 @@
-import React, { useState, useEffect, ReactElement } from "react";
-import type { FC } from "react";
-
-import type {
-    PayPalScriptOptions,
-    PayPalButtonsComponentOptions,
-} from "@paypal/paypal-js";
-import type { StoryFn } from "@storybook/react";
-import type { DocsContextProps } from "@storybook/addon-docs";
+import React, { useState, useEffect, ReactElement, type FC } from "react";
 import { action } from "@storybook/addon-actions";
-import type {
-    CreateOrderBraintreeActions,
-    OnApproveBraintreeActions,
-    OnApproveBraintreeData,
-} from "../../types";
 
 import { PayPalScriptProvider } from "../../index";
 import { BraintreePayPalButtons } from "../../components/braintree/BraintreePayPalButtons";
@@ -35,6 +22,18 @@ import {
 import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError, defaultProps } from "../commons";
 import { getDefaultCode, getBillingAgreementCode } from "./code";
+
+import type {
+    PayPalScriptOptions,
+    PayPalButtonsComponentOptions,
+} from "@paypal/paypal-js";
+import type { StoryFn } from "@storybook/react";
+import type { DocsContextProps } from "@storybook/addon-docs";
+import type {
+    CreateOrderBraintreeActions,
+    OnApproveBraintreeActions,
+    OnApproveBraintreeData,
+} from "../../types";
 
 type StoryProps = {
     style: PayPalButtonsComponentOptions["style"];

--- a/src/stories/commons.tsx
+++ b/src/stories/commons.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { type FC } from "react";
 import { action } from "@storybook/addon-actions";
 
 import { ERROR, SDK } from "./constants";

--- a/src/stories/components/CopyButton.tsx
+++ b/src/stories/components/CopyButton.tsx
@@ -1,5 +1,6 @@
-import React, { useState, ReactElement } from "react";
+import React, { useState, type ReactElement } from "react";
 import { useSandpack } from "@codesandbox/sandpack-react";
+
 import type {
     FontWeightProperty,
     FloatProperty,

--- a/src/stories/components/CustomSandpack.tsx
+++ b/src/stories/components/CustomSandpack.tsx
@@ -1,17 +1,18 @@
-import React, { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 import {
     SandpackProvider,
     SandpackThemeProvider,
     SandpackPreview,
     SandpackCodeEditor,
 } from "@codesandbox/sandpack-react";
+
+import CopyButton from "./CopyButton";
+
 import type {
     SandpackPredefinedTemplate,
     SandpackFile,
 } from "@codesandbox/sandpack-react/dist/types/types";
 import "@codesandbox/sandpack-react/dist/index.css";
-
-import CopyButton from "./CopyButton";
 
 // Default styles
 const CUSTOM_STYLE = {

--- a/src/stories/components/DocPageStructure.tsx
+++ b/src/stories/components/DocPageStructure.tsx
@@ -9,10 +9,10 @@ import {
 } from "@storybook/addon-docs";
 import dedent from "ts-dedent";
 
-import type { DocsContextProps } from "@storybook/addon-docs/dist/ts3.9/blocks";
-
 import CustomSandpack from "./CustomSandpack";
 import { SANDPACK_STYLES } from "../constants";
+
+import type { DocsContextProps } from "@storybook/addon-docs/dist/ts3.9/blocks";
 
 /**
  * Component to override the default DocPage structure from the storybook

--- a/src/stories/payPalButtons/PayPalButtons.stories.tsx
+++ b/src/stories/payPalButtons/PayPalButtons.stories.tsx
@@ -1,15 +1,7 @@
-import React, { FC, ReactElement, useEffect } from "react";
-import type {
-    PayPalScriptOptions,
-    CreateOrderActions,
-    OnApproveActions,
-    PayPalButtonsComponentOptions,
-} from "@paypal/paypal-js";
-import type { StoryFn } from "@storybook/react";
-import type { DocsContextProps } from "@storybook/addon-docs";
+import React, { useEffect, type FC, type ReactElement } from "react";
+import { action } from "@storybook/addon-actions";
 
 import { usePayPalScriptReducer, DISPATCH_ACTION } from "../../index";
-import { action } from "@storybook/addon-actions";
 import { PayPalScriptProvider, PayPalButtons, FUNDING } from "../../index";
 import { getOptionsFromQueryString, generateRandomString } from "../utils";
 import {
@@ -27,6 +19,15 @@ import {
 import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError, defaultProps } from "../commons";
 import { getDefaultCode, getDonateCode } from "./code";
+
+import type {
+    PayPalScriptOptions,
+    CreateOrderActions,
+    OnApproveActions,
+    PayPalButtonsComponentOptions,
+} from "@paypal/paypal-js";
+import type { StoryFn } from "@storybook/react";
+import type { DocsContextProps } from "@storybook/addon-docs";
 
 type StoryProps = {
     style: PayPalButtonsComponentOptions["style"];

--- a/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect, useRef, CSSProperties } from "react";
+import React, {
+    useState,
+    useEffect,
+    useRef,
+    type CSSProperties,
+    type FC,
+    type ReactElement,
+} from "react";
 import { action } from "@storybook/addon-actions";
-import type { FC, ReactElement } from "react";
-
-import type { StoryFn } from "@storybook/react";
-import type { DocsContextProps } from "@storybook/addon-docs";
-import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 import {
     PayPalScriptProvider,
@@ -28,6 +30,10 @@ import {
 import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError } from "../commons";
 import { getDefaultCode, getExpirationDateCode } from "./codeHostedFields";
+
+import type { StoryFn } from "@storybook/react";
+import type { DocsContextProps } from "@storybook/addon-docs";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 type StoryProps = {
     amount: string;

--- a/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
@@ -1,9 +1,5 @@
-import React, { useState, useEffect } from "react";
-import type { FC, ReactElement } from "react";
+import React, { useState, useEffect, type FC, type ReactElement } from "react";
 import { action } from "@storybook/addon-actions";
-
-import type { DocsContextProps } from "@storybook/addon-docs";
-import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 import {
     PayPalScriptProvider,
@@ -21,6 +17,9 @@ import { COMPONENT_PROPS_CATEGORY, COMPONENT_EVENTS, SDK } from "../constants";
 import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError } from "../commons";
 import { getDefaultCode } from "./codeProvider";
+
+import type { DocsContextProps } from "@storybook/addon-docs";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 const uid = generateRandomString();
 const TOKEN_URL = `${HEROKU_SERVER}/api/paypal/hosted-fields/auth`;

--- a/src/stories/payPalMarks/PayPalMarks.stories.tsx
+++ b/src/stories/payPalMarks/PayPalMarks.stories.tsx
@@ -1,15 +1,6 @@
-import React, { useState, FC, ChangeEvent } from "react";
-import type { PayPalScriptOptions } from "@paypal/paypal-js";
-import type {
-    CreateOrderActions,
-    OnApproveData,
-    OnApproveActions,
-    PayPalButtonsComponentOptions,
-} from "@paypal/paypal-js";
+import React, { useState, type FC, type ChangeEvent } from "react";
 import { action } from "@storybook/addon-actions";
 
-import type { StoryFn } from "@storybook/react";
-import type { DocsContextProps } from "@storybook/addon-docs";
 import {
     PayPalScriptProvider,
     PayPalMarks,
@@ -29,6 +20,16 @@ import {
 import { InEligibleError, defaultProps } from "../commons";
 import DocPageStructure from "../components/DocPageStructure";
 import { getDefaultCode, getRadioButtonsCode } from "./code";
+
+import type { StoryFn } from "@storybook/react";
+import type { DocsContextProps } from "@storybook/addon-docs";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
+import type {
+    CreateOrderActions,
+    OnApproveData,
+    OnApproveActions,
+    PayPalButtonsComponentOptions,
+} from "@paypal/paypal-js";
 
 const scriptProviderOptions: PayPalScriptOptions = {
     "client-id": "test",

--- a/src/stories/payPalScriptProvider/PayPalScriptProvider.stories.tsx
+++ b/src/stories/payPalScriptProvider/PayPalScriptProvider.stories.tsx
@@ -1,9 +1,5 @@
-import React, { FC, ReactElement } from "react";
+import React, { type FC, type ReactElement } from "react";
 import { action } from "@storybook/addon-actions";
-
-import type { StoryFn } from "@storybook/react";
-import type { DocsContextProps } from "@storybook/addon-docs";
-import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 import { getOptionsFromQueryString } from "../utils";
 import {
@@ -18,6 +14,10 @@ import {
 import { usePayPalScriptReducer } from "../../hooks/scriptProviderHooks";
 import DocPageStructure from "../components/DocPageStructure";
 import { getDefaultCode } from "./code";
+
+import type { StoryFn } from "@storybook/react";
+import type { DocsContextProps } from "@storybook/addon-docs";
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
 
 const scriptProviderOptions: PayPalScriptOptions = {
     "client-id": "test",

--- a/src/stories/subscriptions/Subscriptions.stories.tsx
+++ b/src/stories/subscriptions/Subscriptions.stories.tsx
@@ -1,15 +1,5 @@
-import React, { FC, ReactElement, useEffect } from "react";
+import React, { useEffect, type FC, type ReactElement } from "react";
 import { action } from "@storybook/addon-actions";
-
-import type { StoryFn } from "@storybook/react";
-import type { DocsContextProps } from "@storybook/addon-docs";
-import type {
-    PayPalScriptOptions,
-    CreateSubscriptionActions,
-    CreateOrderActions,
-    OnApproveData,
-    OnApproveActions,
-} from "@paypal/paypal-js";
 
 import {
     PayPalScriptProvider,
@@ -27,8 +17,18 @@ import {
 } from "../constants";
 import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError, defaultProps } from "../commons";
-import type { PayPalButtonsComponentProps } from "../../types/paypalButtonTypes";
 import { getDefaultCode } from "./code";
+
+import type { StoryFn } from "@storybook/react";
+import type { DocsContextProps } from "@storybook/addon-docs";
+import type { PayPalButtonsComponentProps } from "../../types/paypalButtonTypes";
+import type {
+    PayPalScriptOptions,
+    CreateSubscriptionActions,
+    CreateOrderActions,
+    OnApproveData,
+    OnApproveActions,
+} from "@paypal/paypal-js";
 
 const subscriptionOptions: PayPalScriptOptions = {
     "client-id": "test",

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -1,8 +1,8 @@
 import reactElementToJSXString from "react-element-to-jsx-string";
 import format from "string-template";
-
 import { SDK_QUERY_KEYS } from "@paypal/sdk-constants/dist/module";
-import { ReactNode } from "react";
+
+import type { ReactNode } from "react";
 
 // FIXME: problem with union on key
 type TokenResponse = {

--- a/src/stories/venmo/VenmoButton.stories.tsx
+++ b/src/stories/venmo/VenmoButton.stories.tsx
@@ -1,14 +1,14 @@
-import React, { FC } from "react";
-
-import type { PayPalScriptOptions } from "@paypal/paypal-js";
-import type { StoryFn } from "@storybook/react";
-import type { DocsContextProps } from "@storybook/addon-docs";
+import React, { type FC } from "react";
 
 import { PayPalScriptProvider, FUNDING, PayPalButtons } from "../../index";
 import { getOptionsFromQueryString, generateRandomString } from "../utils";
 import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError } from "../commons";
 import { getDefaultCode } from "./code";
+
+import type { PayPalScriptOptions } from "@paypal/paypal-js";
+import type { StoryFn } from "@storybook/react";
+import type { DocsContextProps } from "@storybook/addon-docs";
 
 const scriptProviderOptions: PayPalScriptOptions = {
     "client-id":

--- a/src/types/scriptProviderTypes.ts
+++ b/src/types/scriptProviderTypes.ts
@@ -1,6 +1,7 @@
 import { SCRIPT_ID } from "../constants";
 import { BraintreePayPalCheckout } from "./braintree/paypalCheckout";
 import { DISPATCH_ACTION, SCRIPT_LOADING_STATE } from "./enums";
+
 import type { ReactNode, Dispatch } from "react";
 import type { PayPalScriptOptions } from "@paypal/paypal-js";
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,12 +1,14 @@
 import { mock } from "jest-mock-extended";
+
+import { SDK_SETTINGS } from "./constants";
 import {
     getPayPalWindowNamespace,
     getBraintreeWindowNamespace,
     hashStr,
 } from "./utils";
+
 import type { PayPalNamespace } from "@paypal/paypal-js";
 import type { BraintreeNamespace } from "./types";
-import { SDK_SETTINGS } from "./constants";
 
 describe("getPayPalWindowNamespace", () => {
     const mockPayPalNamespace = mock<PayPalNamespace>();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import {
     DEFAULT_PAYPAL_NAMESPACE,
     DEFAULT_BRAINTREE_NAMESPACE,
 } from "./constants";
+
 import type { PayPalNamespace } from "@paypal/paypal-js";
 import type { BraintreeNamespace } from "./types";
 


### PR DESCRIPTION
### Description
PR organize/standardize the imports statements on the files. The PR doesn't introduce any new changes, only organize the top of the files.

### Why are we making these changes?
To have a better organization in the project files and avoid creating duplicate lines from the same absolute path to import different functions/types.

### Note
This is a proposal of organization any comment/idea/advice is welcome. Also if this is not helpful we can reject the PR.