### PR TITLE
chore: minor edit on Braintree merchant-id

### DIFF
--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -46,12 +46,12 @@ export const BraintreePayPalButtons: FC<
                     })
                     .then((clientInstance) => {
                         return braintree.paypalCheckout.create({
-                            client: clientInstance,
-                            merchantAccountId: getMerchantId(
+                            ...getMerchantId(
                                 providerContext.options[
                                     SDK_SETTINGS.MERCHANT_CLIENT_ID
                                 ]
                             ),
+                            client: clientInstance,
                         });
                     })
                     .then((paypalCheckoutInstance) => {

--- a/src/components/braintree/utils.test.ts
+++ b/src/components/braintree/utils.test.ts
@@ -198,18 +198,16 @@ describe("getBraintreeNamespace", () => {
 });
 
 describe("getMerchantId", () => {
-    test("should return undefined", () => {
-        expect(getMerchantId(undefined)).toBeUndefined();
-    });
-
-    test("should return an empty string", () => {
-        expect(getMerchantId([])).toBe("");
+    test.each([undefined, []])("should return undefined", (value) => {
+        expect(getMerchantId(value)).toEqual(expect.objectContaining({}));
     });
 
     test.each(["merchantId", ["merchantId"]])(
         "should return the merchant when is string or an array with one value",
         (value) => {
-            expect(getMerchantId(value)).toBe("merchantId");
+            expect(getMerchantId(value)).toEqual(
+                expect.objectContaining({ merchantAccountId: "merchantId" })
+            );
         }
     );
 

--- a/src/components/braintree/utils.ts
+++ b/src/components/braintree/utils.ts
@@ -108,12 +108,12 @@ export const getBraintreeNamespace = (
  */
 export const getMerchantId = (
     source?: Array<string> | string
-): string | undefined => {
+): { merchantAccountId?: string } => {
     const isSourceArray = Array.isArray(source);
 
     if (isSourceArray && source.length > 1) {
         throw new Error(BRAINTREE_MULTIPLE_MERCHANT_IDS_ERROR_MESSAGE);
     }
 
-    return source?.toString();
+    return source ? { merchantAccountId: source.toString() } : {};
 };

--- a/src/stories/braintree/BraintreePayPalButtons.stories.tsx
+++ b/src/stories/braintree/BraintreePayPalButtons.stories.tsx
@@ -46,6 +46,7 @@ type StoryProps = {
 const uid = generateRandomString();
 const scriptProviderOptions: PayPalScriptOptions = {
     "client-id": "test",
+    "merchant-id": "PZ9S7J5YJKLNS",
     components: "buttons",
     ...getOptionsFromQueryString(),
 };


### PR DESCRIPTION
### Description
The PR contains a fix to avoid sending empty strings in the merchant-id options.

### Why are we making these changes?
To avoid issues creating a payment with an empty merchant-id string.