### PR TITLE
fix(hostedFields): problems with code template

### DIFF
--- a/src/stories/payPalHostedFields/codeHostedFields.ts
+++ b/src/stories/payPalHostedFields/codeHostedFields.ts
@@ -130,7 +130,7 @@ const INVALID_COLOR = {
 const SubmitPayment = ({ customStyle }) => {
 	const [paying, setPaying] = useState(false);
 	const cardHolderName = useRef(null);
-	const hostedField = usePayPalHostedFields();
+	const { cardFields: hostedField } = usePayPalHostedFields();
 
 	const handleClick = () => {
 		if (hostedField) {


### PR DESCRIPTION
### Description
The HostedFields example is broken due to the code template being wrong and it isn't calling the `getState` function from the `cardFields`.

###
Why are we making these changes?
To fix the failing HostedFields example in Codesanbox.