### PR TITLE
feat(hostedFields): enable installments option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "7.7.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@paypal/paypal-js": "^5.0.5",
+                "@paypal/paypal-js": "^5.0.6",
                 "@paypal/sdk-constants": "^1.0.116"
             },
             "devDependencies": {
@@ -4223,9 +4223,9 @@
             }
         },
         "node_modules/@paypal/paypal-js": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-5.0.5.tgz",
-            "integrity": "sha512-OV+0Z2MgHVj6dQiE58x9vq6upWWvajbyuwYlDQ4aBkwj6sLLsdkXO8HDuYJPYoVzbX3+/Di6fNKvlUlCJiv+zA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-5.0.6.tgz",
+            "integrity": "sha512-q40h/Rc2Dus5p7Ctgq8EQyyqWGVCdfaezi4D5eWSIl2+p0FHL1mBA4XnXYgv9FPYejrVUmnIATdbqBdEYwasYg==",
             "dependencies": {
                 "promise-polyfill": "^8.2.3"
             }
@@ -28620,9 +28620,9 @@
             }
         },
         "@paypal/paypal-js": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-5.0.5.tgz",
-            "integrity": "sha512-OV+0Z2MgHVj6dQiE58x9vq6upWWvajbyuwYlDQ4aBkwj6sLLsdkXO8HDuYJPYoVzbX3+/Di6fNKvlUlCJiv+zA==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-5.0.6.tgz",
+            "integrity": "sha512-q40h/Rc2Dus5p7Ctgq8EQyyqWGVCdfaezi4D5eWSIl2+p0FHL1mBA4XnXYgv9FPYejrVUmnIATdbqBdEYwasYg==",
             "requires": {
                 "promise-polyfill": "^8.2.3"
             }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "homepage": "https://paypal.github.io/react-paypal-js/",
     "dependencies": {
-        "@paypal/paypal-js": "^5.0.5",
+        "@paypal/paypal-js": "^5.0.6",
         "@paypal/sdk-constants": "^1.0.116"
     },
     "devDependencies": {

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.test.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.test.tsx
@@ -426,4 +426,57 @@ describe("PayPalHostedFieldsProvider", () => {
         ).toBeFalsy();
         jest.useRealTimers();
     });
+
+    test("should call render function with installments option", async () => {
+        render(
+            <PayPalScriptProvider
+                options={{
+                    "client-id": "test-client",
+                    currency: "USD",
+                    intent: "authorize",
+                    "data-client-token": "test-data-client-token",
+                    components: "hosted-fields",
+                }}
+            >
+                <PayPalHostedFieldsProvider
+                    createOrder={jest.fn()}
+                    installments={{
+                        onInstallmentsRequested: jest.fn(),
+                        onInstallmentsAvailable: jest.fn(),
+                        onInstallmentsError: jest.fn(),
+                    }}
+                >
+                    <PayPalHostedField
+                        className="number"
+                        hostedFieldType={PAYPAL_HOSTED_FIELDS_TYPES.NUMBER}
+                        options={{ selector: ".number" }}
+                    />
+                    <PayPalHostedField
+                        className="expiration"
+                        hostedFieldType={
+                            PAYPAL_HOSTED_FIELDS_TYPES.EXPIRATION_DATE
+                        }
+                        options={{ selector: ".expiration" }}
+                    />
+                    <PayPalHostedField
+                        className="cvv"
+                        hostedFieldType={PAYPAL_HOSTED_FIELDS_TYPES.CVV}
+                        options={{ selector: ".cvv" }}
+                    />
+                </PayPalHostedFieldsProvider>
+            </PayPalScriptProvider>
+        );
+
+        await waitFor(() => {
+            expect(window?.paypal?.HostedFields?.render).toBeCalledWith(
+                expect.objectContaining({
+                    installments: {
+                        onInstallmentsRequested: expect.any(Function),
+                        onInstallmentsAvailable: expect.any(Function),
+                        onInstallmentsError: expect.any(Function),
+                    },
+                })
+            );
+        });
+    });
 });

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
@@ -31,7 +31,7 @@ Take a look to this link if that is the case: https://developer.paypal.com/docs/
 */
 export const PayPalHostedFieldsProvider: FC<
     PayPalHostedFieldsComponentProps
-> = ({ styles, createOrder, notEligibleError, children }) => {
+> = ({ styles, createOrder, notEligibleError, children, installments }) => {
     const [{ options, loadingStatus }] = useScriptProviderContext();
     const [isEligible, setIsEligible] = useState<boolean>(true);
     const [cardFields, setCardFields] = useState<HostedFieldsHandler>();
@@ -76,8 +76,9 @@ export const PayPalHostedFieldsProvider: FC<
             .render({
                 // Call your server to set up the transaction
                 createOrder: createOrder,
-                styles: styles,
                 fields: registeredFields.current,
+                installments,
+                styles,
             })
             .then((cardFieldsInstance) => {
                 if (hostedFieldsContainerRef.current) {

--- a/src/stories/payPalHostedFields/codeHostedFields.ts
+++ b/src/stories/payPalHostedFields/codeHostedFields.ts
@@ -228,7 +228,7 @@ export default function App() {
 											{
 												amount: {
 													value: "${args.amount}", // Here change the amount if needed
-													currency_code: "${args.currency}", // Here change the currency if needed
+													currency_code: "USD", // Here change the currency if needed
 												},
 											},
 										],

--- a/src/types/payPalHostedFieldTypes.ts
+++ b/src/types/payPalHostedFieldTypes.ts
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from "react";
-import type { HostedFieldsHandler } from "@paypal/paypal-js";
+import type { HostedFieldsHandler, Installments } from "@paypal/paypal-js";
 
 export type PayPalHostedFieldsNamespace = {
     components: string | undefined;
@@ -107,6 +107,7 @@ export interface PayPalHostedFieldsComponentProps {
      * Function to manually create the transaction from your server
      */
     createOrder: () => Promise<string>;
+    installments?: Installments;
     children: ReactNode;
     /**
      * [Styling options](https://developer.paypal.com/braintree/docs/guides/hosted-fields/styling/javascript/v3) for customizing the fields appearance


### PR DESCRIPTION
### Description
The PR contains code improvements for the `PayPalHostedFieldsProvider` component in order to enable the `installments` option in the render process of the hosted fields.

### Why are we making these changes? 
A short description can be found [here](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-765)
The main reason to make the change is to allow clients to use the `installments` option in the hosted fields render process. The previous version does not expose the ability to set the `installments` callback.

### Dependent Changes
https://github.com/paypal/paypal-js/pull/239