### PR TITLE
chore(story): update the Hosted Fields story example

### DIFF
--- a/src/stories/payPalHostedFields/codeHostedFields.ts
+++ b/src/stories/payPalHostedFields/codeHostedFields.ts
@@ -130,46 +130,50 @@ const INVALID_COLOR = {
 const SubmitPayment = ({ customStyle }) => {
 	const [paying, setPaying] = useState(false);
 	const cardHolderName = useRef(null);
-	const { cardFields: hostedField } = usePayPalHostedFields();
+	const hostedField = usePayPalHostedFields();
 
 	const handleClick = () => {
-		if (hostedField) {
-			if (
-				Object.values(hostedField.getState().fields).some(
-					(field) => !field.isValid
-				) ||
-				!cardHolderName?.current?.value
-			) {
-				return alert(
-					"The payment form is invalid, please check it before execute the payment"
-				);
-			}
-			setPaying(true);
-			hostedField
-				.submit({
-					cardholderName: cardHolderName?.current?.value,
-				})
-				.then((data) => {
-					// Your logic to capture the transaction
-					fetch("url_to_capture_transaction", {
-						method: "post",
-					})
-						.then((response) => response.json())
-						.then((data) => {
-							// Here use the captured info
-						})
-						.catch((err) => {
-							// Here handle error
-						})
-						.finally(() => {
-							setPaying(false);
-						});
-				})
-				.catch((err) => {
-					// Here handle error
-					setPaying(false);
-				});
+		if (!hostedField?.cardFields) {
+            const childErrorMessage = 'Unable to find any child components in the <PayPalHostedFieldsProvider />';
+
+            action(ERROR)(childErrorMessage);
+            throw new Error(childErrorMessage);
+        }
+		const isFormInvalid =
+			Object.values(hostedField.cardFields.getState().fields).some(
+				(field) => !field.isValid
+			) || !cardHolderName?.current?.value;
+		
+		if (isFormInvalid) {
+			return alert(
+				"The payment form is invalid"
+			);
 		}
+		setPaying(true);
+		hostedField.cardFields
+			.submit({
+				cardholderName: cardHolderName?.current?.value,
+			})
+			.then((data) => {
+				// Your logic to capture the transaction
+				fetch("url_to_capture_transaction", {
+					method: "post",
+				})
+					.then((response) => response.json())
+					.then((data) => {
+						// Here use the captured info
+					})
+					.catch((err) => {
+						// Here handle error
+					})
+					.finally(() => {
+						setPaying(false);
+					});
+			})
+			.catch((err) => {
+				// Here handle error
+				setPaying(false);
+			});
 	};
 
 	return (


### PR DESCRIPTION
### Description
The PR includes a code change about how to use the Hosted Fields. Instead of using an alias changing the `cardFields` name to `hostedField`, the idea is to go straight with the instance and the key as follows: `hostedField.cardFields`.

### Why are we making these changes?
The example code for Hosted Fields can introduce some confusion because we're using an alias on line 75 of the file `PayPalHostedFields.stories.tsx` take a look [here](https://github.com/paypal/react-paypal-js/blob/904c580046c1f7d3d83311ab735f1a56c856f8ff/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx#L75)
More details [here](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-778)

### Screenshots
Before:
<img width="957" alt="before" src="https://user-images.githubusercontent.com/26287838/169847680-5cfcd41a-8c7d-4160-9aa3-010b6a9ac11f.png">

After:
<img width="952" alt="after" src="https://user-images.githubusercontent.com/26287838/169847703-f76bf228-d74f-4f0b-a992-ef9e0f242aa7.png">

 