### PR TITLE
chore(typescript): remove type from import

### DIFF
--- a/src/components/PayPalButtons.test.tsx
+++ b/src/components/PayPalButtons.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type ReactNode } from "react";
+import React, { useState } from "react";
 import {
     render,
     waitFor,
@@ -8,16 +8,17 @@ import {
 } from "@testing-library/react";
 import { ErrorBoundary } from "react-error-boundary";
 import { mock } from "jest-mock-extended";
-import {
-    loadScript,
-    PayPalNamespace,
-    type PayPalButtonsComponent,
-    type PayPalButtonsComponentOptions,
-} from "@paypal/paypal-js";
+import { loadScript, PayPalNamespace } from "@paypal/paypal-js";
 
 import { PayPalButtons } from "./PayPalButtons";
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
 import { FUNDING } from "../index";
+
+import type { ReactNode } from "react";
+import type {
+    PayPalButtonsComponent,
+    PayPalButtonsComponentOptions,
+} from "@paypal/paypal-js";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),

--- a/src/components/PayPalButtons.tsx
+++ b/src/components/PayPalButtons.tsx
@@ -1,14 +1,10 @@
-import React, {
-    useEffect,
-    useRef,
-    useState,
-    type FunctionComponent,
-} from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
 import { SDK_SETTINGS } from "../constants";
 
+import type { FunctionComponent } from "react";
 import type { PayPalButtonsComponent, OnInitActions } from "@paypal/paypal-js";
 import type { PayPalButtonsComponentProps } from "../types";
 

--- a/src/components/PayPalMarks.test.tsx
+++ b/src/components/PayPalMarks.test.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from "react";
+import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
 import { loadScript, PayPalNamespace } from "@paypal/paypal-js";
@@ -7,6 +7,8 @@ import { ErrorBoundary } from "react-error-boundary";
 import { PayPalScriptProvider } from "../components/PayPalScriptProvider";
 import { PayPalMarks } from "./PayPalMarks";
 import { FUNDING } from "../index";
+
+import type { ReactNode } from "react";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),

--- a/src/components/PayPalMarks.tsx
+++ b/src/components/PayPalMarks.tsx
@@ -1,15 +1,10 @@
-import React, {
-    useEffect,
-    useRef,
-    useState,
-    type FC,
-    type ReactNode,
-} from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
 import { SDK_SETTINGS } from "../constants";
 
+import type { FC, ReactNode } from "react";
 import type {
     PayPalMarksComponentOptions,
     PayPalMarksComponent,

--- a/src/components/PayPalMessages.test.tsx
+++ b/src/components/PayPalMessages.test.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from "react";
+import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
 import { loadScript, PayPalNamespace } from "@paypal/paypal-js";
@@ -6,6 +6,8 @@ import { ErrorBoundary } from "react-error-boundary";
 
 import { PayPalMessages } from "..";
 import { PayPalScriptProvider } from "../components/PayPalScriptProvider";
+
+import type { ReactNode } from "react";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),

--- a/src/components/PayPalMessages.tsx
+++ b/src/components/PayPalMessages.tsx
@@ -1,14 +1,10 @@
-import React, {
-    useEffect,
-    useRef,
-    useState,
-    type FunctionComponent,
-} from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { getPayPalWindowNamespace, generateErrorMessage } from "../utils";
 import { SDK_SETTINGS } from "../constants";
 
+import type { FC } from "react";
 import type {
     PayPalMessagesComponentOptions,
     PayPalMessagesComponent,
@@ -24,9 +20,7 @@ export interface PayPalMessagesComponentProps
 This `<PayPalMessages />` messages component renders a credit messaging on upstream merchant sites.
 It relies on the `<PayPalScriptProvider />` parent component for managing state related to loading the JS SDK script.
 */
-export const PayPalMessages: FunctionComponent<
-    PayPalMessagesComponentProps
-> = ({
+export const PayPalMessages: FC<PayPalMessagesComponentProps> = ({
     className = "",
     forceReRender = [],
     ...messageProps

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, type FC } from "react";
+import React, { useEffect, useReducer } from "react";
 import { loadScript } from "@paypal/paypal-js";
 
 import {
@@ -7,11 +7,10 @@ import {
     scriptReducer,
 } from "../context/scriptProviderContext";
 import { SCRIPT_ID, SDK_SETTINGS, LOAD_SCRIPT_ERROR } from "../constants";
-import {
-    SCRIPT_LOADING_STATE,
-    DISPATCH_ACTION,
-    type ScriptProviderProps,
-} from "../types";
+import { SCRIPT_LOADING_STATE, DISPATCH_ACTION } from "../types";
+
+import type { FC } from "react";
+import type { ScriptProviderProps } from "../types";
 
 /**
 This `<PayPalScriptProvider />` component takes care of loading the JS SDK `<script>`.

--- a/src/components/braintree/BraintreePayPalButtons.tsx
+++ b/src/components/braintree/BraintreePayPalButtons.tsx
@@ -1,13 +1,15 @@
-import React, { useState, useEffect, type FC } from "react";
+import React, { useState, useEffect } from "react";
 
 import { SDK_SETTINGS, LOAD_SCRIPT_ERROR } from "../../constants";
 import { PayPalButtons } from "../PayPalButtons";
 import { useScriptProviderContext } from "../../hooks/scriptProviderHooks";
 import { decorateActions, getBraintreeNamespace } from "./utils";
-import {
-    DISPATCH_ACTION,
-    type BraintreePayPalButtonsComponentProps,
-    type PayPalButtonsComponentProps,
+import { DISPATCH_ACTION } from "../../types";
+
+import type { FC } from "react";
+import type {
+    BraintreePayPalButtonsComponentProps,
+    PayPalButtonsComponentProps,
 } from "../../types";
 
 /**

--- a/src/components/hostedFields/PayPalHostedField.test.tsx
+++ b/src/components/hostedFields/PayPalHostedField.test.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode, type ProviderProps } from "react";
+import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -6,6 +6,7 @@ import { PayPalHostedField } from "./PayPalHostedField";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
 
+import type { ReactNode, ProviderProps } from "react";
 import type { PayPalHostedFieldContext } from "../../types";
 
 const onError = jest.fn();

--- a/src/components/hostedFields/PayPalHostedField.tsx
+++ b/src/components/hostedFields/PayPalHostedField.tsx
@@ -1,7 +1,8 @@
-import React, { useContext, useEffect, type FC } from "react";
+import React, { useContext, useEffect } from "react";
 
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
 
+import type { FC } from "react";
 import type { PayPalHostedFieldProps } from "../../types/payPalHostedFieldTypes";
 
 /**

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.test.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.test.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from "react";
+import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { ErrorBoundary } from "react-error-boundary";
 import { loadScript } from "@paypal/paypal-js";
@@ -10,6 +10,7 @@ import { PayPalHostedField } from "./PayPalHostedField";
 import { PAYPAL_HOSTED_FIELDS_TYPES } from "../../types/enums";
 import { EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE } from "../../constants";
 
+import type { ReactNode } from "react";
 import type {
     PayPalNamespace,
     PayPalHostedFieldsComponent,

--- a/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
+++ b/src/components/hostedFields/PayPalHostedFieldsProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, type FC } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 import { PayPalHostedFieldsContext } from "../../context/payPalHostedFieldsContext";
 import { useHostedFieldsRegister } from "./hooks";
@@ -14,6 +14,7 @@ import {
 } from "../../types/enums";
 import { getPayPalWindowNamespace } from "../../utils";
 
+import type { FC } from "react";
 import type { PayPalHostedFieldsComponentProps } from "../../types/payPalHostedFieldTypes";
 import type {
     PayPalHostedFieldsComponent,

--- a/src/components/hostedFields/hooks.ts
+++ b/src/components/hostedFields/hooks.ts
@@ -1,5 +1,6 @@
-import { useRef, type MutableRefObject } from "react";
+import { useRef } from "react";
 
+import type { MutableRefObject } from "react";
 import type { PayPalHostedFieldsRegistered } from "../../types/payPalHostedFieldTypes";
 
 /**

--- a/src/context/scriptProviderContext.ts
+++ b/src/context/scriptProviderContext.ts
@@ -2,16 +2,15 @@ import { createContext } from "react";
 
 import { hashStr } from "../utils";
 import { SCRIPT_ID, SDK_SETTINGS } from "../constants";
-import {
-    DISPATCH_ACTION,
-    SCRIPT_LOADING_STATE,
-    type ScriptContextState,
-    type ReactPayPalScriptOptions,
-    type ScriptReducerAction,
-} from "../types";
+import { DISPATCH_ACTION, SCRIPT_LOADING_STATE } from "../types";
 
 import type { PayPalScriptOptions } from "@paypal/paypal-js";
 import type { BraintreePayPalCheckout } from "../types/braintree/paypalCheckout";
+import type {
+    ScriptContextState,
+    ReactPayPalScriptOptions,
+    ScriptReducerAction,
+} from "../types";
 
 /**
  * Generate a new random identifier for react-paypal-js

--- a/src/hooks/scriptProviderHooks.ts
+++ b/src/hooks/scriptProviderHooks.ts
@@ -5,11 +5,12 @@ import {
     validateReducer,
     validateBraintreeAuthorizationData,
 } from "./contextValidator";
-import {
-    SCRIPT_LOADING_STATE,
-    type ScriptContextDerivedState,
-    type ScriptContextState,
-    type ScriptReducerAction,
+import { SCRIPT_LOADING_STATE } from "../types";
+
+import type {
+    ScriptContextDerivedState,
+    ScriptContextState,
+    ScriptReducerAction,
 } from "../types";
 
 /**

--- a/src/stories/PayPalMessages.stories.tsx
+++ b/src/stories/PayPalMessages.stories.tsx
@@ -1,10 +1,11 @@
-import React, { type FC } from "react";
+import React from "react";
 
 import { PayPalScriptProvider, PayPalMessages } from "../index";
 import DocPageStructure from "./components/DocPageStructure";
 import { getOptionsFromQueryString } from "./utils";
 import { COMPONENT_PROPS_CATEGORY } from "./constants";
 
+import type { FC } from "react";
 import type { PayPalScriptOptions } from "@paypal/paypal-js";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";

--- a/src/stories/braintree/BraintreePayPalButtons.stories.tsx
+++ b/src/stories/braintree/BraintreePayPalButtons.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactElement, type FC } from "react";
+import React, { useState, useEffect, ReactElement } from "react";
 import { action } from "@storybook/addon-actions";
 
 import { PayPalScriptProvider } from "../../index";
@@ -23,6 +23,7 @@ import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError, defaultProps } from "../commons";
 import { getDefaultCode, getBillingAgreementCode } from "./code";
 
+import type { FC } from "react";
 import type {
     PayPalScriptOptions,
     PayPalButtonsComponentOptions,

--- a/src/stories/commons.tsx
+++ b/src/stories/commons.tsx
@@ -1,7 +1,9 @@
-import React, { type FC } from "react";
+import React from "react";
 import { action } from "@storybook/addon-actions";
 
 import { ERROR, SDK } from "./constants";
+
+import type { FC } from "react";
 
 /**
  * Functional component to render a custom ineligible error UI

--- a/src/stories/components/CopyButton.tsx
+++ b/src/stories/components/CopyButton.tsx
@@ -1,6 +1,7 @@
-import React, { useState, type ReactElement } from "react";
+import React, { useState } from "react";
 import { useSandpack } from "@codesandbox/sandpack-react";
 
+import type { ReactElement } from "react";
 import type {
     FontWeightProperty,
     FloatProperty,

--- a/src/stories/components/CustomSandpack.tsx
+++ b/src/stories/components/CustomSandpack.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactElement } from "react";
+import React from "react";
 import {
     SandpackProvider,
     SandpackThemeProvider,
@@ -8,6 +8,7 @@ import {
 
 import CopyButton from "./CopyButton";
 
+import type { ReactElement } from "react";
 import type {
     SandpackPredefinedTemplate,
     SandpackFile,

--- a/src/stories/payPalButtons/PayPalButtons.stories.tsx
+++ b/src/stories/payPalButtons/PayPalButtons.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, type FC, type ReactElement } from "react";
+import React, { useEffect } from "react";
 import { action } from "@storybook/addon-actions";
 
 import { usePayPalScriptReducer, DISPATCH_ACTION } from "../../index";
@@ -20,6 +20,7 @@ import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError, defaultProps } from "../commons";
 import { getDefaultCode, getDonateCode } from "./code";
 
+import type { FC, ReactElement } from "react";
 import type {
     PayPalScriptOptions,
     CreateOrderActions,

--- a/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
@@ -1,11 +1,4 @@
-import React, {
-    useState,
-    useEffect,
-    useRef,
-    type CSSProperties,
-    type FC,
-    type ReactElement,
-} from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { action } from "@storybook/addon-actions";
 
 import {
@@ -31,6 +24,7 @@ import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError } from "../commons";
 import { getDefaultCode, getExpirationDateCode } from "./codeHostedFields";
 
+import type { CSSProperties, FC, ReactElement } from "react";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 import type { PayPalScriptOptions } from "@paypal/paypal-js";

--- a/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, type FC, type ReactElement } from "react";
+import React, { useState, useEffect } from "react";
 import { action } from "@storybook/addon-actions";
 
 import {
@@ -18,6 +18,7 @@ import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError } from "../commons";
 import { getDefaultCode } from "./codeProvider";
 
+import type { FC, ReactElement } from "react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 import type { PayPalScriptOptions } from "@paypal/paypal-js";
 

--- a/src/stories/payPalMarks/PayPalMarks.stories.tsx
+++ b/src/stories/payPalMarks/PayPalMarks.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type FC, type ChangeEvent } from "react";
+import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 
 import {
@@ -21,6 +21,7 @@ import { InEligibleError, defaultProps } from "../commons";
 import DocPageStructure from "../components/DocPageStructure";
 import { getDefaultCode, getRadioButtonsCode } from "./code";
 
+import type { FC, ChangeEvent } from "react";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 import type { PayPalScriptOptions } from "@paypal/paypal-js";

--- a/src/stories/payPalScriptProvider/PayPalScriptProvider.stories.tsx
+++ b/src/stories/payPalScriptProvider/PayPalScriptProvider.stories.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, type ReactElement } from "react";
+import React from "react";
 import { action } from "@storybook/addon-actions";
 
 import { getOptionsFromQueryString } from "../utils";
@@ -15,6 +15,7 @@ import { usePayPalScriptReducer } from "../../hooks/scriptProviderHooks";
 import DocPageStructure from "../components/DocPageStructure";
 import { getDefaultCode } from "./code";
 
+import type { FC, ReactElement } from "react";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 import type { PayPalScriptOptions } from "@paypal/paypal-js";

--- a/src/stories/subscriptions/Subscriptions.stories.tsx
+++ b/src/stories/subscriptions/Subscriptions.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, type FC, type ReactElement } from "react";
+import React, { useEffect } from "react";
 import { action } from "@storybook/addon-actions";
 
 import {
@@ -19,6 +19,7 @@ import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError, defaultProps } from "../commons";
 import { getDefaultCode } from "./code";
 
+import type { FC, ReactElement } from "react";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";
 import type { PayPalButtonsComponentProps } from "../../types/paypalButtonTypes";

--- a/src/stories/venmo/VenmoButton.stories.tsx
+++ b/src/stories/venmo/VenmoButton.stories.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from "react";
+import React from "react";
 
 import { PayPalScriptProvider, FUNDING, PayPalButtons } from "../../index";
 import { getOptionsFromQueryString, generateRandomString } from "../utils";
@@ -6,6 +6,7 @@ import DocPageStructure from "../components/DocPageStructure";
 import { InEligibleError } from "../commons";
 import { getDefaultCode } from "./code";
 
+import type { FC } from "react";
 import type { PayPalScriptOptions } from "@paypal/paypal-js";
 import type { StoryFn } from "@storybook/react";
 import type { DocsContextProps } from "@storybook/addon-docs";


### PR DESCRIPTION
### Description
Remove the `import { type TYPE }` to avoid problems with an older version of Typescript.

### Why are we making these changes?
Check details [here](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-782)