### PR TITLE
chore: update Braintree dependency

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const LOAD_SCRIPT_ERROR = "Failed to load the PayPal JS SDK script.";
 export const EMPTY_BRAINTREE_AUTHORIZATION_ERROR_MESSAGE =
     "Invalid authorization data. Use data-client-token or data-user-id-token to authorize.";
 
-const braintreeVersion = "3.84.0";
+const braintreeVersion = "3.88.1";
 export const BRAINTREE_SOURCE = `https://js.braintreegateway.com/web/${braintreeVersion}/js/client.min.js`;
 export const BRAINTREE_PAYPAL_CHECKOUT_SOURCE = `https://js.braintreegateway.com/web/${braintreeVersion}/js/paypal-checkout.min.js`;
 


### PR DESCRIPTION
Braintree version updated from 3.84 to 3.88.1