### PR TITLE
fix: add memoization in PayPalScriptProvider to break infinite loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@paypal/react-paypal-js",
-    "version": "7.8.1",
+    "version": "7.8.2",
     "description": "React components for the PayPal JS SDK",
     "keywords": [
         "react",

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -5,6 +5,7 @@ import {
     getPayPalWindowNamespace,
     getBraintreeWindowNamespace,
     hashStr,
+    shallowCompareObjects,
 } from "./utils";
 
 import type { PayPalNamespace } from "@paypal/paypal-js";
@@ -72,5 +73,42 @@ describe("hashStr", () => {
         ).toMatchInlineSnapshot(
             `"iiuovjsqddgseaaouopvvtcqciewjblfycugmepzoirvygvhquvfthtdttqasyqcdzbzaepjvxhbwsrjhhcurjzroipxqyishjiubldxsiumrlgiscmehhggkwzxusrrdpdxisuuektdeudjrtosskdpcksyhttbqsqsvdsoaugkffisgkusjvhthnqmlzgqccmutvqaztoqu"`
         );
+    });
+});
+
+describe("shallowCompareObjects", () => {
+    test("should return true if the objects are the same", () => {
+        const obj = { a: 1, b: 2 };
+        expect(shallowCompareObjects(obj, obj)).toBe(true);
+    });
+
+    test("should return true if the objects has the same value but different references", () => {
+        const objA = { a: 1, b: 2 };
+        const objB = { a: 1, b: 2 };
+        expect(shallowCompareObjects(objA, objB)).toBe(true);
+    });
+
+    test("should return false if the objects has different values", () => {
+        const objA = { a: 1, b: 2 };
+        const objB = { a: 1, b: 3 };
+        expect(shallowCompareObjects(objA, objB)).toBe(false);
+    });
+
+    test("should return false if the objects has different keys", () => {
+        const objA = { a: 1, b: 2 };
+        const objB = { a: 1, b: 2, c: 3 };
+        expect(shallowCompareObjects(objA, objB)).toBe(false);
+    });
+
+    test("should return false for two equal nested objects", () => {
+        const objA = { a: 1, b: { c: 2 } };
+        const objB = { a: 1, b: { c: 2 } };
+        expect(shallowCompareObjects(objA, objB)).toBe(false);
+    });
+
+    test("should return true for two different nested objects", () => {
+        const objA = { a: 1, b: { c: 2 } };
+        const objB = { a: 1, b: { c: 3 } };
+        expect(shallowCompareObjects(objA, objB)).toBe(false);
     });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,3 +91,13 @@ export function generateErrorMessage({
 
     return errorMessage;
 }
+
+export function shallowCompareObjects(
+    objA: Record<string, unknown>,
+    objB: Record<string, unknown>
+): boolean {
+    if (Object.keys(objA).length !== Object.keys(objB).length) {
+        return false;
+    }
+    return Object.keys(objA).every((key) => objA[key] === objB[key]);
+}


### PR DESCRIPTION
ISSUE: 
Using the `dispatch` function from the `usePayPalScriptReducer` hook in the `useEffect` callback is causing the infinity loop. 

Infinity loop is causing a massive amount of resource fetch which is resulting in throttling (429 HTTP code).

EXAMPLE: 
Code example available on https://paypal.github.io/react-paypal-js/?path=/docs/example-paypalbuttons--default does not trigger this issue because the `useEffect` dependency array is incomplete. 
``` 
    const [{ options, isPending }, dispatch] = usePayPalScriptReducer();

    useEffect(() => {
        dispatch({
            type: "resetOptions",
            value: {
                ...options,
                currency: currency,
            },
        });
    }, [currency, showSpinner]); // <-- missing `options` dependency
```
Skipping items of dependency array is not a good practice, as explained here https://github.com/facebook/create-react-app/issues/6880#issuecomment-485912528

Fixing that will trigger the loop.
``` 
    const [{ options, isPending }, dispatch] = usePayPalScriptReducer();

    useEffect(() => {
        dispatch({
            type: "resetOptions",
            value: {
                ...options,
                currency: currency,
            },
        });
    }, [currency, options, showSpinner]); 
```

SOLUTION:
This PR is adding memoization of the `options` object. The comparison between the current and previous values of the `options` object is made to ensure that the object will change its reference only when its value changes.

Replacing the `useReducer` hook with multiple `useState` hooks for each state element and exposing callback functions instead of `dispatch` will result in better isolation of state changes. Also, it should prevent similar issues in the future. However, it will be a breaking change, so this PR is limited to fix of only one issue.

OTHER:
Probably fixes #287 
