### PR TITLE
chore(storybook): change client-id for hosted-fields example

### DIFF
--- a/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
@@ -42,7 +42,7 @@ const RED_COLOR = "#dc3545";
 const GREEN_COLOR = "#28a745";
 const scriptProviderOptions: PayPalScriptOptions = {
     clientId:
-        "AdOu-W3GPkrfuTbJNuW9dWVijxvhaXHFIRuKrLDwu14UDwTTHWMFkUwuu9D8I1MAQluERl9cFOd7Mfqe",
+        "AduyjUJ0A7urUcWtGCTjanhRBSzOSn9_GKUzxWDnf51YaV1eZNA0ZAFhebIV_Eq-daemeI7dH05KjLWm",
     components: "buttons,hosted-fields",
     ...getOptionsFromQueryString(),
 };

--- a/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFieldsProvider.stories.tsx
@@ -26,7 +26,7 @@ const uid = generateRandomString();
 const TOKEN_URL = `${FLY_SERVER}/api/paypal/hosted-fields/auth`;
 const scriptProviderOptions: PayPalScriptOptions = {
     clientId:
-        "AdOu-W3GPkrfuTbJNuW9dWVijxvhaXHFIRuKrLDwu14UDwTTHWMFkUwuu9D8I1MAQluERl9cFOd7Mfqe",
+        "AduyjUJ0A7urUcWtGCTjanhRBSzOSn9_GKUzxWDnf51YaV1eZNA0ZAFhebIV_Eq-daemeI7dH05KjLWm",
     components: "buttons,hosted-fields",
     ...getOptionsFromQueryString(),
 };

--- a/src/stories/payPalHostedFields/codeHostedFields.ts
+++ b/src/stories/payPalHostedFields/codeHostedFields.ts
@@ -211,7 +211,7 @@ export default function App() {
 				<PayPalScriptProvider
 					options={{
 						clientId:
-							"AdOu-W3GPkrfuTbJNuW9dWVijxvhaXHFIRuKrLDwu14UDwTTHWMFkUwuu9D8I1MAQluERl9cFOd7Mfqe",
+							"AduyjUJ0A7urUcWtGCTjanhRBSzOSn9_GKUzxWDnf51YaV1eZNA0ZAFhebIV_Eq-daemeI7dH05KjLWm",
 						components: "buttons,hosted-fields",
 						dataClientToken: clientToken,
 						intent: "capture",

--- a/src/stories/payPalHostedFields/codeProvider.ts
+++ b/src/stories/payPalHostedFields/codeProvider.ts
@@ -27,7 +27,7 @@ export default function App() {
 				<PayPalScriptProvider
 					options={{
 						clientId:
-							"AdOu-W3GPkrfuTbJNuW9dWVijxvhaXHFIRuKrLDwu14UDwTTHWMFkUwuu9D8I1MAQluERl9cFOd7Mfqe",
+							"AduyjUJ0A7urUcWtGCTjanhRBSzOSn9_GKUzxWDnf51YaV1eZNA0ZAFhebIV_Eq-daemeI7dH05KjLWm",
 						components: "buttons,hosted-fields",
 						dataClientToken: clientToken,
 						intent: "capture",


### PR DESCRIPTION
The current sandbox Client ID for the Hosted Card Fields Storybook demo is ineligible. This PR changes it to use a new Client ID that is eligible.

### Before
<img width="1250" alt="Screen Shot 2023-07-03 at 3 49 11 PM" src="https://github.com/paypal/react-paypal-js/assets/534034/e8dd7a09-ec8c-4d1b-b245-1ddbec6ebe2d">


### After
<img width="1250" alt="Screen Shot 2023-07-03 at 3 48 47 PM" src="https://github.com/paypal/react-paypal-js/assets/534034/18172ec2-e480-4045-99c1-0ad8030c8320">

