### PR TITLE
chore: recommend using server-side api calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,26 +173,49 @@ Here's an example:
 import { PayPalScriptProvider, PayPalButtons } from "@paypal/react-paypal-js";
 
 export default function App() {
+    function createOrder() {
+        return fetch("/my-server/create-paypal-order", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            // use the "body" param to optionally pass additional order information
+            // like product ids and quantities
+            body: JSON.stringify({
+                cart: [
+                    {
+                        id: "YOUR_PRODUCT_ID",
+                        quantity: "YOUR_PRODUCT_QUANTITY",
+                    },
+                ],
+            }),
+        })
+            .then((response) => response.json())
+            .then((order) => order.id);
+    }
+    function onApprove(data) {
+          return fetch("/my-server/capture-paypal-order", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              orderID: data.orderID
+            })
+          })
+          .then((response) => response.json())
+          .then((orderData) => {
+                const name = orderData.payer.name.given_name;
+                alert(`Transaction completed by ${name}`);
+          });
+
+        }
+    }
     return (
         <PayPalScriptProvider options={{ clientId: "test" }}>
             <PayPalButtons
-                createOrder={(data, actions) => {
-                    return actions.order.create({
-                        purchase_units: [
-                            {
-                                amount: {
-                                    value: "1.99",
-                                },
-                            },
-                        ],
-                    });
-                }}
-                onApprove={(data, actions) => {
-                    return actions.order.capture().then((details) => {
-                        const name = details.payer.name.given_name;
-                        alert(`Transaction completed by ${name}`);
-                    });
-                }}
+                createOrder={createOrder}
+                onApprove={onApprove}
             />
         </PayPalScriptProvider>
     );

--- a/src/stories/payPalButtons/code.ts
+++ b/src/stories/payPalButtons/code.ts
@@ -1,159 +1,172 @@
-import { generateFundingSource } from "../utils";
+import {
+    generateFundingSource,
+    CREATE_ORDER_URL,
+    CAPTURE_ORDER_URL,
+} from "../utils";
 
 import type { Args } from "@storybook/addons/dist/ts3.9/types";
 
-const IMPORT_STATEMENT = `import { useEffect } from "react";
+export const getDefaultCode = (args: Args): string =>
+    `
 import {
     PayPalScriptProvider,
     PayPalButtons,
     usePayPalScriptReducer
-} from "@paypal/react-paypal-js";`;
+} from "@paypal/react-paypal-js";
 
-const getPayPalScripProvider = (currency: string) =>
-    `<PayPalScriptProvider
-                options={{
-                    "clientId": "test",
-                    components: "buttons",
-                    currency: "${currency}"
-                }}
-            >`;
-
-const buttonWrapperEffect = (
-    dependencies: string
-) => `// usePayPalScriptReducer can be use only inside children of PayPalScriptProviders
-    // This is the main reason to wrap the PayPalButtons in a new component
-    const [{ options, isPending }, dispatch] = usePayPalScriptReducer();
-
-    useEffect(() => {
-        dispatch({
-            type: "resetOptions",
-            value: {
-                ...options,
-                currency: currency,
-            },
-        });
-    }, [${dependencies}]);
-`;
-
-export const getDefaultCode = (args: Args): string =>
-    `${IMPORT_STATEMENT}
-
-// This values are the props in the UI
-const amount = "${args.amount}";
-const currency = "${args.currency}";
+// This value is from the props in the UI
 const style = ${JSON.stringify(args.style)};
 
-// Custom component to wrap the PayPalButtons and handle currency changes
-const ButtonWrapper = ({ currency, showSpinner }) => {
-    ${buttonWrapperEffect("currency, showSpinner")}
+function createOrder() {
+    // replace this url with your server
+    return fetch("${CREATE_ORDER_URL}", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        // use the "body" param to optionally pass additional order information
+        // like product ids and quantities
+        body: JSON.stringify({
+            cart: [
+                {
+                    sku: "1blwyeo8",
+                    quantity: 2,
+                },
+            ],
+        }),
+    })
+        .then((response) => response.json())
+        .then((order) => {
+            // Your code here after create the order
+            return order.id;
+        });
+}
+function onApprove(data) {
+    // replace this url with your server
+    return fetch("${CAPTURE_ORDER_URL}", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            orderID: data.orderID,
+        }),
+    })
+        .then((response) => response.json())
+        .then((orderData) => {
+            // Your code here after capture the order
+        });
+}
 
-    return (<>
+// Custom component to wrap the PayPalButtons and show loading spinner
+const ButtonWrapper = ({ showSpinner }) => {
+    const [{ isPending }] = usePayPalScriptReducer();
+
+    return (
+        <>
             { (showSpinner && isPending) && <div className="spinner" /> }
             <PayPalButtons
                 style={style}
                 disabled={${args.disabled}}
-                forceReRender={[amount, currency, style]}
+                forceReRender={[style]}
                 ${generateFundingSource(args.fundingSource as string)}
-                createOrder={(data, actions) => {
-                    return actions.order
-                        .create({
-                            purchase_units: [
-                                {
-                                    amount: {
-                                        currency_code: currency,
-                                        value: amount,
-                                    },
-                                },
-                            ],
-                        })
-                        .then((orderId) => {
-                            // Your code here after create the order
-                            return orderId;
-                        });
-                }}
-                onApprove={function (data, actions) {
-                    return actions.order.capture().then(function () {
-                        // Your code here after capture the order
-                    });
-                }}
+                createOrder={createOrder}
+                onApprove={onApprove}
             />
         </>
     );
 }
 
 export default function App() {
-	return (
-		<div style={{ maxWidth: "${args.size}px", minHeight: "200px" }}>
-            ${getPayPalScripProvider(args.currency)}
-				<ButtonWrapper
-                    currency={currency}
-                    showSpinner={${args.showSpinner}}
-                />
-			</PayPalScriptProvider>
-		</div>
-	);
-}`;
-
-export const getDonateCode = (args: Args): string =>
-    `${IMPORT_STATEMENT}
-
-const ButtonWrapper = ({ currency }) => {
-    ${buttonWrapperEffect("currency")}
-
-     return (<PayPalButtons
-        fundingSource="paypal"
-        style={${JSON.stringify({
-            ...(args.style as Record<string, unknown>),
-            label: "donate",
-        })}}
-        disabled={${args.disabled}}
-        createOrder={(data, actions) => {
-            return actions.order
-                .create({
-                    purchase_units: [
-                        {
-                            amount: {
-                                value: "${args.amount}",
-                                breakdown: {
-                                    item_total: {
-                                        currency_code: "${args.currency}",
-                                        value: "${args.amount}",
-                                    },
-                                },
-                            },
-                            items: [
-                                {
-                                    name: "donation-example",
-                                    quantity: "1",
-                                    unit_amount: {
-                                        currency_code: "${args.currency}",
-                                        value: "${args.amount}",
-                                    },
-                                    category: "DONATION",
-                                },
-                            ],
-                        },
-                    ],
-                })
-                .then((orderId) => {
-                    // Your code here after create the donation
-                    return orderId;
-                });
-        }}
-    />
-     );
-}
-
- export default function App() {
-     return (
-        <div
-             style={{ maxWidth: "750px", minHeight: "200px" }}
-        >
-            ${getPayPalScripProvider(args.currency)}
-                <ButtonWrapper
-                    currency={"${args.currency}"}
-                />
+    return (
+        <div style={{ maxWidth: "${args.size}px", minHeight: "200px" }}>
+            <PayPalScriptProvider options={{ clientId: "test", components: "buttons", currency: "USD" }}>
+                <ButtonWrapper showSpinner={${args.showSpinner}} />
             </PayPalScriptProvider>
         </div>
     );
- }`;
+}`;
+
+export const getDonateCode = (args: Args): string =>
+    `
+import {
+    PayPalScriptProvider,
+    PayPalButtons,
+    usePayPalScriptReducer
+} from "@paypal/react-paypal-js";
+
+// This value is from the props in the UI
+const style = ${JSON.stringify(args.style)};
+
+function createOrder() {
+    // replace this url with your server
+    return fetch("${CREATE_ORDER_URL}", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        // use the "body" param to optionally pass additional order information
+        // like product ids and quantities
+        body: JSON.stringify({
+            cart: [
+                {
+                    sku: "etanod01",
+                    quantity: 1,
+                },
+            ],
+        }),
+    })
+        .then((response) => response.json())
+        .then((order) => {
+            // Your code here after create the order
+            return order.id;
+        });
+}
+function onApprove(data) {
+    // replace this url with your server
+    return fetch("${CAPTURE_ORDER_URL}", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            orderID: data.orderID,
+        }),
+    })
+        .then((response) => response.json())
+        .then((orderData) => {
+            // Your code here after capture the order
+        });
+}
+
+// Custom component to wrap the PayPalButtons and show loading spinner
+const ButtonWrapper = ({ showSpinner }) => {
+    const [{ isPending }] = usePayPalScriptReducer();
+
+    return (
+        <>
+            { (showSpinner && isPending) && <div className="spinner" /> }
+            <PayPalButtons
+                fundingSource="paypal"
+                style={${JSON.stringify({
+                    ...(args.style as Record<string, unknown>),
+                    label: "donate",
+                })}}
+                disabled={${args.disabled}}
+                forceReRender={[style]}
+                createOrder={createOrder}
+                onApprove={onApprove}
+            />
+        </>
+    );
+}
+
+export default function App() {
+    return (
+        <div style={{ maxWidth: "${args.size}px", minHeight: "200px" }}>
+            <PayPalScriptProvider options={{ clientId: "test", components: "buttons", currency: "USD" }}>
+                <ButtonWrapper showSpinner={${args.showSpinner}} />
+            </PayPalScriptProvider>
+        </div>
+    );
+}`;

--- a/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
+++ b/src/stories/payPalHostedFields/PayPalHostedFields.stories.tsx
@@ -12,6 +12,8 @@ import {
     generateRandomString,
     getClientToken,
     FLY_SERVER,
+    CREATE_ORDER_URL,
+    CAPTURE_ORDER_URL,
 } from "../utils";
 import {
     COMPONENT_PROPS_CATEGORY,
@@ -37,7 +39,6 @@ type StoryProps = {
 
 const uid = generateRandomString();
 const TOKEN_URL = `${FLY_SERVER}/api/paypal/generate-client-token`;
-const CREATE_ORDER_URL = `${FLY_SERVER}/api/paypal/create-order`;
 const RED_COLOR = "#dc3545";
 const GREEN_COLOR = "#28a745";
 const scriptProviderOptions: PayPalScriptOptions = {
@@ -49,16 +50,6 @@ const scriptProviderOptions: PayPalScriptOptions = {
 const CREATE_ORDER = "createOrder";
 const SUBMIT_FORM = "submitForm";
 const CAPTURE_ORDER = "captureOrder";
-
-/**
- * Get dynamically the capture order URL to fetch the payment info
- *
- * @param orderId the order identifier
- * @returns an URL string
- */
-function captureOrderUrl(): string {
-    return `${FLY_SERVER}/api/paypal/capture-order`;
-}
 
 /**
  * Functional component to submit the hosted fields form
@@ -95,7 +86,7 @@ const SubmitPayment = ({ customStyle }: { customStyle?: CSSProperties }) => {
                 action(CAPTURE_ORDER)(
                     `Sending ${ORDER_ID} to custom endpoint to capture the payment information`
                 );
-                fetch(captureOrderUrl(), {
+                fetch(CAPTURE_ORDER_URL, {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",

--- a/src/stories/payPalMarks/code.ts
+++ b/src/stories/payPalMarks/code.ts
@@ -1,4 +1,8 @@
-import { generateFundingSource } from "../utils";
+import {
+    generateFundingSource,
+    CREATE_ORDER_URL,
+    CAPTURE_ORDER_URL,
+} from "../utils";
 
 import type { Args } from "@storybook/addons/dist/ts3.9/types";
 
@@ -42,6 +46,47 @@ export default function App() {
 		setSelectedFundingSource(event.target.value);
 	}
 
+	function createOrder() {
+		// replace this url with your server
+		return fetch("${CREATE_ORDER_URL}", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			// use the "body" param to optionally pass additional order information
+			// like product ids and quantities
+			body: JSON.stringify({
+				cart: [
+					{
+						sku: "1blwyeo8",
+						quantity: 2,
+					},
+				],
+			}),
+		})
+			.then((response) => response.json())
+			.then((order) => {
+				// Your code here after create the order
+				return order.id;
+			});
+	}
+	function onApprove(data) {
+		// replace this url with your server
+		return fetch("${CAPTURE_ORDER_URL}", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				orderID: data.orderID,
+			}),
+		})
+			.then((response) => response.json())
+			.then((orderData) => {
+				// Your code here after capture the order
+			});
+	}
+
 	return (
 		<PayPalScriptProvider
 			options={{
@@ -70,28 +115,8 @@ export default function App() {
 				fundingSource={selectedFundingSource}
 				style={style}
 				forceReRender={[selectedFundingSource, style, amount, currency]}
-				createOrder={(data, actions) => {
-					return actions.order
-						.create({
-							purchase_units: [
-								{
-									amount: {
-										currency_code: currency, // Here change the currency if needed
-										value: amount, // Here change the amount if needed
-									},
-								},
-							],
-						})
-						.then((orderId) => {
-							// Your code here after create the order
-							return orderId;
-						});
-				}}
-				onApprove={(data, actions) => {
-					return actions.order.capture().then(function (details) {
-						// Your code here after approve the transaction
-					});
-				}}
+				createOrder={createOrder}
+				onApprove={onApprove}
 			/>
 		</PayPalScriptProvider>
 	);

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -3,6 +3,7 @@ import format from "string-template";
 import { SDK_QUERY_KEYS } from "@paypal/sdk-constants/dist/module";
 
 import type { ReactNode } from "react";
+import type { OrderResponseBody } from "@paypal/paypal-js";
 
 // FIXME: problem with union on key
 type TokenResponse = {
@@ -10,6 +11,9 @@ type TokenResponse = {
 } & { success?: boolean };
 
 export const FLY_SERVER = "https://react-paypal-js-storybook.fly.dev";
+export const CREATE_ORDER_URL = `${FLY_SERVER}/api/paypal/create-order`;
+export const CAPTURE_ORDER_URL = `${FLY_SERVER}/api/paypal/capture-order`;
+
 const CLIENT_TOKEN_URL = `${FLY_SERVER}/api/braintree/generate-client-token`;
 const SALE_URL = `${FLY_SERVER}/api/braintree/sale`;
 const allowedSDKQueryParams = Object.keys(SDK_QUERY_KEYS).map(
@@ -74,4 +78,32 @@ export function generateFundingSource(fundingSource?: string): string {
     return `fundingSource=${
         fundingSource ? `"${fundingSource}"` : "{undefined}"
     }`;
+}
+
+export function createOrder(
+    cart: { sku: string; quantity: number }[]
+): Promise<OrderResponseBody> {
+    return fetch(CREATE_ORDER_URL, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        // use the "body" param to optionally pass additional order information
+        // like product ids and quantities
+        body: JSON.stringify({ cart }),
+    }).then((response) => response.json());
+}
+
+export function onApprove(data: {
+    orderID: string;
+}): Promise<OrderResponseBody> {
+    return fetch(CAPTURE_ORDER_URL, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            orderID: data.orderID,
+        }),
+    }).then((response) => response.json());
 }


### PR DESCRIPTION
This PR updated the README docs and the storybook examples to use the `<PayPalButtons>` component with server-side api calls. 

### Before
```jsx
<PayPalButtons
    createOrder={(data, actions) => {
        // paypal helper that calls the Orders API on your behalf
        return actions.order.create({ /* your order payload */ })
    }}
/>
```

### After
```jsx
<PayPalButtons
    createOrder={(data, actions) => {
        // fetch call to your own server that will accept whatever payload you design
        // and will call the Orders API for server-to-server communcation
        return fetch("/my-server/create-paypal-order", { /* your custom payload for your server */ })
    }}
/>
```