### PR TITLE
Update stories to include new shipping callbacks

### DIFF
--- a/src/stories/braintree/BraintreePayPalButtons.stories.tsx
+++ b/src/stories/braintree/BraintreePayPalButtons.stories.tsx
@@ -79,6 +79,8 @@ export default {
         createBillingAgreement: { table: { category: COMPONENT_EVENTS } },
         createSubscription: { table: { category: COMPONENT_EVENTS } },
         onShippingChange: { table: { category: COMPONENT_EVENTS } },
+        onShippingAddressChange: { table: { category: COMPONENT_EVENTS } },
+        onShippingOptionsChange: { table: { category: COMPONENT_EVENTS } },
         onApprove: { table: { category: COMPONENT_EVENTS } },
         onCancel: { table: { category: COMPONENT_EVENTS } },
         onClick: { table: { category: COMPONENT_EVENTS } },

--- a/src/stories/payPalButtons/PayPalButtons.stories.tsx
+++ b/src/stories/payPalButtons/PayPalButtons.stories.tsx
@@ -88,6 +88,8 @@ export default {
         createBillingAgreement: { table: { category: COMPONENT_EVENTS } },
         createSubscription: { table: { category: COMPONENT_EVENTS } },
         onShippingChange: { table: { category: COMPONENT_EVENTS } },
+        onShippingAddressChange: { table: { category: COMPONENT_EVENTS } },
+        onShippingOptionsChange: { table: { category: COMPONENT_EVENTS } },
         onApprove: { table: { category: COMPONENT_EVENTS } },
         onCancel: { table: { category: COMPONENT_EVENTS } },
         onClick: { table: { category: COMPONENT_EVENTS } },


### PR DESCRIPTION
This pull request updates the PayPal and Braintree buttons stories to include two new callbacks that were introduced in:

1. https://github.com/paypal/paypal-smart-payment-buttons/pull/679 and
2. https://github.com/paypal/paypal-js/pull/427

**PayPal Stories**:
<img width="1025" alt="Screenshot 2023-09-18 at 15 54 17" src="https://github.com/paypal/react-paypal-js/assets/3824954/8c646c1a-6377-47b7-b664-1ab14a128d3f">


**Braintree Buttons**:
<img width="1040" alt="Screenshot 2023-09-18 at 15 54 43" src="https://github.com/paypal/react-paypal-js/assets/3824954/813bdb5c-2cf8-4e47-9fa5-7d903295919b">

I was hoping to mark the `onShippingChange` callback deprecated within Storybook, but [this issue](https://github.com/storybookjs/storybook/issues/9721#issuecomment-1668176147) suggests it is only possible if we update the JSDoc comment to explicitly have the word `deprecated` (instead of or in addition to the `@deprecated` tag)
