### PR TITLE
feat(constants): log sdk integration source

### DIFF
--- a/src/components/PayPalScriptProvider.test.tsx
+++ b/src/components/PayPalScriptProvider.test.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import { loadScript, PayPalScriptOptions } from "@paypal/paypal-js";
+import {
+    SDK_SETTINGS,
+    SDK_INTEGRATION_SOURCES,
+} from "@paypal/sdk-constants/dist/module";
 
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
-import { SCRIPT_ID, SDK_SETTINGS } from "../constants";
+import { SCRIPT_ID } from "../constants";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),
@@ -47,8 +51,8 @@ describe("<PayPalScriptProvider />", () => {
         expect(loadScript).toHaveBeenCalledWith({
             clientId: "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
-            [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
-                SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
+            [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
+                SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
         });
 
         // verify initial loading state
@@ -73,8 +77,8 @@ describe("<PayPalScriptProvider />", () => {
         expect(loadScript).toHaveBeenCalledWith({
             clientId: "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
-            [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
-                SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
+            [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
+                SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
         });
 
         // verify initial loading state
@@ -139,8 +143,8 @@ describe("<PayPalScriptProvider />", () => {
         expect(loadScript).toHaveBeenCalledWith({
             clientId: "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
-            [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
-                SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
+            [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
+                SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
         });
 
         expect(state.isPending).toBe(true);

--- a/src/components/PayPalScriptProvider.test.tsx
+++ b/src/components/PayPalScriptProvider.test.tsx
@@ -3,7 +3,7 @@ import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import { loadScript, PayPalScriptOptions } from "@paypal/paypal-js";
 import {
     SDK_SETTINGS,
-    SDK_INTEGRATION_SOURCES,
+    JS_SDK_LIBRARIES,
 } from "@paypal/sdk-constants/dist/module";
 
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
@@ -52,7 +52,7 @@ describe("<PayPalScriptProvider />", () => {
             clientId: "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
             [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
-                SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
+                JS_SDK_LIBRARIES.REACT_PAYPAL_JS,
         });
 
         // verify initial loading state
@@ -78,7 +78,7 @@ describe("<PayPalScriptProvider />", () => {
             clientId: "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
             [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
-                SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
+                JS_SDK_LIBRARIES.REACT_PAYPAL_JS,
         });
 
         // verify initial loading state
@@ -144,7 +144,7 @@ describe("<PayPalScriptProvider />", () => {
             clientId: "test",
             [SCRIPT_ID]: expect.stringContaining("react-paypal-js"),
             [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
-                SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
+                JS_SDK_LIBRARIES.REACT_PAYPAL_JS,
         });
 
         expect(state.isPending).toBe(true);

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -1,12 +1,16 @@
 import React, { useEffect, useReducer } from "react";
 import { loadScript } from "@paypal/paypal-js";
+import {
+    SDK_SETTINGS,
+    SDK_INTEGRATION_SOURCES,
+} from "@paypal/sdk-constants/dist/module";
 
 import {
     getScriptID,
     ScriptContext,
     scriptReducer,
 } from "../context/scriptProviderContext";
-import { SCRIPT_ID, SDK_SETTINGS, LOAD_SCRIPT_ERROR } from "../constants";
+import { SCRIPT_ID, LOAD_SCRIPT_ERROR } from "../constants";
 import { SCRIPT_LOADING_STATE, DISPATCH_ACTION } from "../types";
 
 import type { FC } from "react";
@@ -25,8 +29,8 @@ export const PayPalScriptProvider: FC<ScriptProviderProps> = ({
 }: ScriptProviderProps) => {
     const [state, dispatch] = useReducer(scriptReducer, {
         options: {
-            [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
-                SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
+            [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
+                SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
             ...options,
             [SCRIPT_ID]: `${getScriptID(options)}`,
         },

--- a/src/components/PayPalScriptProvider.tsx
+++ b/src/components/PayPalScriptProvider.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useReducer } from "react";
 import { loadScript } from "@paypal/paypal-js";
 import {
     SDK_SETTINGS,
-    SDK_INTEGRATION_SOURCES,
+    JS_SDK_LIBRARIES,
 } from "@paypal/sdk-constants/dist/module";
 
 import {
@@ -30,7 +30,7 @@ export const PayPalScriptProvider: FC<ScriptProviderProps> = ({
     const [state, dispatch] = useReducer(scriptReducer, {
         options: {
             [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
-                SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
+                JS_SDK_LIBRARIES.REACT_PAYPAL_JS,
             ...options,
             [SCRIPT_ID]: `${getScriptID(options)}`,
         },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,8 +8,6 @@ export const SCRIPT_ID = "data-react-paypal-script-id";
 export const SDK_SETTINGS = {
     DATA_CLIENT_TOKEN: "dataClientToken",
     DATA_USER_ID_TOKEN: "dataUserIdToken",
-    DATA_SDK_INTEGRATION_SOURCE: "dataSdkIntegrationSource",
-    DATA_SDK_INTEGRATION_SOURCE_VALUE: "react-paypal-js",
     DATA_NAMESPACE: "dataNamespace",
 };
 export const LOAD_SCRIPT_ERROR = "Failed to load the PayPal JS SDK script.";

--- a/src/context/scriptProviderContext.ts
+++ b/src/context/scriptProviderContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 import {
     SDK_SETTINGS,
-    SDK_INTEGRATION_SOURCES,
+    JS_SDK_LIBRARIES,
 } from "@paypal/sdk-constants/dist/module";
 
 import { hashStr } from "../utils";
@@ -76,7 +76,7 @@ export function scriptReducer(
                 loadingStatus: SCRIPT_LOADING_STATE.PENDING,
                 options: {
                     [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
-                        SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
+                        JS_SDK_LIBRARIES.REACT_PAYPAL_JS,
                     ...action.value,
                     [SCRIPT_ID]: `${getScriptID(action.value)}`,
                 },

--- a/src/context/scriptProviderContext.ts
+++ b/src/context/scriptProviderContext.ts
@@ -1,7 +1,11 @@
 import { createContext } from "react";
+import {
+    SDK_SETTINGS,
+    SDK_INTEGRATION_SOURCES,
+} from "@paypal/sdk-constants/dist/module";
 
 import { hashStr } from "../utils";
-import { SCRIPT_ID, SDK_SETTINGS } from "../constants";
+import { SCRIPT_ID } from "../constants";
 import { DISPATCH_ACTION, SCRIPT_LOADING_STATE } from "../types";
 
 import type { BraintreePayPalCheckout } from "../types/braintree/paypalCheckout";
@@ -71,8 +75,8 @@ export function scriptReducer(
                 ...state,
                 loadingStatus: SCRIPT_LOADING_STATE.PENDING,
                 options: {
-                    [SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE]:
-                        SDK_SETTINGS.DATA_SDK_INTEGRATION_SOURCE_VALUE,
+                    [SDK_SETTINGS.SDK_INTEGRATION_SOURCE]:
+                        SDK_INTEGRATION_SOURCES.REACT_PAYPAL_JS,
                     ...action.value,
                     [SCRIPT_ID]: `${getScriptID(action.value)}`,
                 },

--- a/src/types/paypal-sdk-constants.d.ts
+++ b/src/types/paypal-sdk-constants.d.ts
@@ -1,7 +1,7 @@
 declare module "@paypal/sdk-constants/dist/module" {
-    export const FUNDING: Record<string, string>;
-    export const SDK_QUERY_KEYS: Record<string, string>;
     export const CURRENCY: Record<string, string>;
-    export const SDK_SETTINGS: Record<string, string>;
+    export const FUNDING: Record<string, string>;
     export const SDK_INTEGRATION_SOURCES: Record<string, string>;
+    export const SDK_SETTINGS: Record<string, string>;
+    export const SDK_QUERY_KEYS: Record<string, string>;
 }

--- a/src/types/paypal-sdk-constants.d.ts
+++ b/src/types/paypal-sdk-constants.d.ts
@@ -2,4 +2,6 @@ declare module "@paypal/sdk-constants/dist/module" {
     export const FUNDING: Record<string, string>;
     export const SDK_QUERY_KEYS: Record<string, string>;
     export const CURRENCY: Record<string, string>;
+    export const SDK_SETTINGS: Record<string, string>;
+    export const SDK_INTEGRATION_SOURCES: Record<string, string>;
 }

--- a/src/types/paypal-sdk-constants.d.ts
+++ b/src/types/paypal-sdk-constants.d.ts
@@ -1,7 +1,7 @@
 declare module "@paypal/sdk-constants/dist/module" {
     export const CURRENCY: Record<string, string>;
     export const FUNDING: Record<string, string>;
-    export const SDK_INTEGRATION_SOURCES: Record<string, string>;
+    export const JS_SDK_LIBRARIES: Record<string, string>;
     export const SDK_SETTINGS: Record<string, string>;
     export const SDK_QUERY_KEYS: Record<string, string>;
 }


### PR DESCRIPTION
### Description

Herein lies part of the effort charged by [DTPPCPSDK-1482](https://paypal.atlassian.net/browse/DTPPCPSDK-1482).

### Why are we making these changes?

We are going to get `SDK_SETTINGS` and `SDK_INTEGRATION_SOURCES` from `@paypal/sdk-constants` for logging the JS SDK `data-sdk-integration-source` value.

### Dependent changes

We need to release https://github.com/paypal/paypal-sdk-constants/pull/142 before this will work.