### PR TITLE
chore(ci): upgrade to the checkout action v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⬇️ Checkout repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
-                  token: ${{ secrets.ACCESS_TOKEN }}
+                  ref: ${{github.event.pull_request.head.sha}}
                   fetch-depth: 0
 
             - name: 🤝 Set Node version from .nvmrc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⬇️ Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   ref: ${{github.event.pull_request.head.sha}}
                   fetch-depth: 0

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,8 +12,9 @@ jobs:
 
         steps:
             - name: ⬇️ Checkout repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
+                  ref: ${{github.event.pull_request.head.sha}}
                   fetch-depth: 0
 
             - name: 🤝 Set Node version from .nvmrc

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,7 +12,7 @@ jobs:
 
         steps:
             - name: ⬇️ Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   ref: ${{github.event.pull_request.head.sha}}
                   fetch-depth: 0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⬇️ Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   ref: ${{github.event.pull_request.head.sha}}
                   fetch-depth: 0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,8 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⬇️ Checkout repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
+                  ref: ${{github.event.pull_request.head.sha}}
                   fetch-depth: 0
 
             - name: 🤝 Set Node version from .nvmrc


### PR DESCRIPTION
Upgrading to `actions/checkout` v3 in attempts to fix the npm publish Github Action.