### PR TITLE
chore(ci): fix github permission with publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,4 @@ jobs:
               run: npm run release
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Attempting to fix the following error from https://github.com/paypal/react-paypal-js/actions/runs/8087741241/job/22100366726:
```
✔ tagging release v8.1.4
ℹ Run `git push --follow-tags origin main && npm publish` to publish
> @paypal/react-paypal-js@8.1.3 postrelease
> git push && git push --follow-tags && npm run build && npm publish
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: error: Required status check "main" is expected.        
To https://github.com/paypal/react-paypal-js
 ! [remote rejected] main -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/paypal/react-paypal-js'
Error: Process completed with exit code 1.
```