### PR TITLE
Feature/add card fields form

### DIFF
--- a/src/components/cardFields/PayPalCardFieldsForm.test.tsx
+++ b/src/components/cardFields/PayPalCardFieldsForm.test.tsx
@@ -1,0 +1,210 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { ErrorBoundary } from "react-error-boundary";
+import { loadScript } from "@paypal/paypal-js";
+import { mock } from "jest-mock-extended";
+
+import { PayPalScriptProvider } from "../PayPalScriptProvider";
+import { PayPalCardFieldsProvider } from "./PayPalCardFieldsProvider";
+import { CARD_FIELDS_CONTEXT_ERROR } from "../../constants";
+import { PayPalCardFieldsForm } from "./PayPalCardFieldsForm";
+
+import type { PayPalCardFieldsComponent } from "../../types";
+import type { ReactNode } from "react";
+
+const onError = jest.fn();
+const CVVField = jest.fn();
+const ExpiryField = jest.fn();
+const NumberField = jest.fn();
+const NameField = jest.fn();
+const CardFields = jest.fn(
+    () =>
+        ({
+            isEligible: jest.fn().mockReturnValue(true),
+            CVVField: CVVField.mockReturnValue({
+                render: jest.fn(() => Promise.resolve()),
+                close: jest.fn(() => Promise.resolve()),
+            }),
+            ExpiryField: ExpiryField.mockReturnValue({
+                render: jest.fn(() => Promise.resolve()),
+                close: jest.fn(() => Promise.resolve()),
+            }),
+            NumberField: NumberField.mockReturnValue({
+                render: jest.fn(() => Promise.resolve()),
+                close: jest.fn(() => Promise.resolve()),
+            }),
+            NameField: NameField.mockReturnValue({
+                render: jest.fn(() => Promise.resolve()),
+                close: jest.fn(() => Promise.resolve()),
+            }),
+        } as unknown as PayPalCardFieldsComponent)
+);
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <ErrorBoundary fallback={<div>Error</div>} onError={onError}>
+        {children}
+    </ErrorBoundary>
+);
+
+jest.mock("@paypal/paypal-js", () => ({
+    loadScript: jest.fn(),
+}));
+const mockCreateOrder = mock<() => Promise<string>>();
+const mockOnApprove = mock<() => Promise<string>>();
+const mockOnError = mock<() => void>();
+const mockOnChange = mock<() => void>();
+const mockOnBlur = mock<() => void>();
+const mockOnFocus = mock<() => void>();
+const mockOnInputSubmitRequest = mock<() => void>();
+
+describe("PayPalCardFieldsForm", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+
+        window.paypal = {
+            CardFields,
+            version: "",
+        };
+
+        (loadScript as jest.Mock).mockResolvedValue(window.paypal);
+    });
+    test("should render each component with the glocal style passed", async () => {
+        const spyConsoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation();
+
+        render(
+            <PayPalScriptProvider
+                options={{
+                    clientId: "test-client",
+                    currency: "USD",
+                    intent: "authorize",
+                    components: "card-fields",
+                }}
+            >
+                <PayPalCardFieldsProvider
+                    onApprove={mockOnApprove}
+                    createOrder={mockCreateOrder}
+                    onError={mockOnError}
+                >
+                    <PayPalCardFieldsForm
+                        style={{ input: { color: "black" } }}
+                    />
+                </PayPalCardFieldsProvider>
+            </PayPalScriptProvider>,
+            { wrapper }
+        );
+        await waitFor(() => expect(onError).toHaveBeenCalledTimes(0));
+
+        [CVVField, ExpiryField, NameField, NumberField].forEach((field) => {
+            expect(field).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    style: { input: { color: "black" } },
+                })
+            );
+        });
+
+        spyConsoleError.mockRestore();
+    });
+
+    test("should render component with specific input event callbacks", async () => {
+        const spyConsoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation();
+
+        render(
+            <PayPalScriptProvider
+                options={{
+                    clientId: "test-client",
+                    currency: "USD",
+                    intent: "authorize",
+                    components: "card-fields",
+                }}
+            >
+                <PayPalCardFieldsProvider
+                    onApprove={mockOnApprove}
+                    createOrder={mockCreateOrder}
+                    onError={mockOnError}
+                >
+                    <PayPalCardFieldsForm
+                        inputEvents={{
+                            onChange: mockOnChange,
+                            onFocus: mockOnFocus,
+                            onBlur: mockOnBlur,
+                            onInputSubmitRequest: mockOnInputSubmitRequest,
+                        }}
+                    />
+                </PayPalCardFieldsProvider>
+            </PayPalScriptProvider>,
+            { wrapper }
+        );
+        await waitFor(() => expect(onError).toHaveBeenCalledTimes(0));
+
+        [CVVField, ExpiryField, NameField, NumberField].forEach((field) => {
+            expect(field).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    inputEvents: {
+                        onChange: mockOnChange,
+                        onFocus: mockOnFocus,
+                        onBlur: mockOnBlur,
+                        onInputSubmitRequest: mockOnInputSubmitRequest,
+                    },
+                })
+            );
+        });
+
+        spyConsoleError.mockRestore();
+    });
+
+    test("should render component with specific container classes", async () => {
+        const spyConsoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation();
+
+        const { container } = render(
+            <PayPalScriptProvider
+                options={{
+                    clientId: "test-client",
+                    currency: "USD",
+                    intent: "authorize",
+                    components: "card-fields",
+                    dataClientToken: "test-data-client-token",
+                }}
+            >
+                <PayPalCardFieldsProvider
+                    onApprove={mockOnApprove}
+                    createOrder={mockCreateOrder}
+                    onError={mockOnError}
+                >
+                    <PayPalCardFieldsForm className="class1 class2 class3" />
+                </PayPalCardFieldsProvider>
+            </PayPalScriptProvider>,
+            { wrapper }
+        );
+        await waitFor(() => expect(onError).toHaveBeenCalledTimes(0));
+
+        const renderedElement = container.querySelector(".class1");
+        expect(renderedElement?.classList.contains("class2")).toBeTruthy();
+        expect(renderedElement?.classList.contains("class3")).toBeTruthy();
+
+        spyConsoleError.mockRestore();
+    });
+
+    test("should fail rendering the component when context is invalid", async () => {
+        const spyConsoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation();
+
+        render(
+            <PayPalScriptProvider options={{ clientId: "" }}>
+                <PayPalCardFieldsForm />
+            </PayPalScriptProvider>,
+            { wrapper }
+        );
+
+        await waitFor(() => expect(onError).toBeCalledTimes(4)); // 4 times, 1 for each field in the form.
+        expect(onError.mock.calls[0][0].message).toBe(
+            CARD_FIELDS_CONTEXT_ERROR
+        );
+        spyConsoleError.mockRestore();
+    });
+});

--- a/src/components/cardFields/PayPalCardFieldsForm.test.tsx
+++ b/src/components/cardFields/PayPalCardFieldsForm.test.tsx
@@ -67,7 +67,7 @@ describe("PayPalCardFieldsForm", () => {
 
         (loadScript as jest.Mock).mockResolvedValue(window.paypal);
     });
-    test("should render each component with the glocal style passed", async () => {
+    test("should render each component with the global style passed", async () => {
         const spyConsoleError = jest
             .spyOn(console, "error")
             .mockImplementation();

--- a/src/components/cardFields/PayPalCardFieldsForm.tsx
+++ b/src/components/cardFields/PayPalCardFieldsForm.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { PayPalCardFieldsFormOptions } from "../../types";
+import { PayPalCardField } from "./PayPalCardField";
+import { FlexContainer } from "../ui/FlexContainer";
+
+export const PayPalCardFieldsForm: React.FC<PayPalCardFieldsFormOptions> = ({
+    className,
+    ...options
+}) => {
+    return (
+        <>
+            <style
+                dangerouslySetInnerHTML={{
+                    __html: `.w-full { width:100%; }`,
+                }}
+            />
+            <div className={className}>
+                <PayPalCardField fieldName="NameField" {...options} />
+                <PayPalCardField fieldName="NumberField" {...options} />
+                <FlexContainer>
+                    <PayPalCardField
+                        fieldName="ExpiryField"
+                        className="w-full"
+                        {...options}
+                    />
+                    <PayPalCardField
+                        fieldName="CVVField"
+                        className="w-full"
+                        {...options}
+                    />
+                </FlexContainer>
+            </div>
+        </>
+    );
+};

--- a/src/components/ui/FlexContainer.tsx
+++ b/src/components/ui/FlexContainer.tsx
@@ -1,0 +1,7 @@
+import React, { ReactNode } from "react";
+
+export const FlexContainer: React.FC<{ children: ReactNode }> = ({
+    children,
+}) => {
+    return <div style={{ display: "flex", width: "100%" }}>{children}</div>;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from "./components/cardFields/PayPalNameField";
 export * from "./components/cardFields/PayPalNumberField";
 export * from "./components/cardFields/PayPalExpiryField";
 export * from "./components/cardFields/PayPalCVVField";
+export * from "./components/cardFields/PayPalCardFieldsForm";
 export * from "./components/cardFields/context";
 export { usePayPalCardFields } from "./components/cardFields/hooks";
 

--- a/src/types/payPalCardFieldsTypes.ts
+++ b/src/types/payPalCardFieldsTypes.ts
@@ -25,6 +25,11 @@ export type PayPalCardFieldsIndividualFieldOptions = FieldOptions & {
     className?: string;
 };
 
+export type PayPalCardFieldsFormOptions = Omit<
+    PayPalCardFieldsIndividualFieldOptions,
+    "placeholder"
+>;
+
 export type PayPalCardFieldsNamespace = {
     components: string | string[] | undefined;
 } & { [DATA_NAMESPACE: string]: string | undefined };


### PR DESCRIPTION
Ticket: DTPPCPSDK-2102

This PR intends to add our `PayPalCardFieldsForm` for merchants to use as a standalone component. Merchants will still have access to our `usePayPalCardFields` hook to handle their own submit logic and render their own submit button with their own styling.

<img width="1103" alt="Screenshot 2024-04-18 at 11 00 16 a m" src="https://github.com/paypal/react-paypal-js/assets/101415858/b02d58d2-557e-4f05-b272-f850a7bfefb5">
