### PR TITLE
refactor: simplify template literals in types definition for ScriptReducerAction 

### DIFF
--- a/src/components/PayPalScriptProvider.test.tsx
+++ b/src/components/PayPalScriptProvider.test.tsx
@@ -5,6 +5,7 @@ import { loadScript, PayPalScriptOptions } from "@paypal/paypal-js";
 import { PayPalScriptProvider } from "./PayPalScriptProvider";
 import { usePayPalScriptReducer } from "../hooks/scriptProviderHooks";
 import { SCRIPT_ID, SDK_SETTINGS } from "../constants";
+import { DISPATCH_ACTION } from "../types/enums";
 
 jest.mock("@paypal/paypal-js", () => ({
     loadScript: jest.fn(),
@@ -290,7 +291,7 @@ function ResetParamsOnClick({
 
     function onClick() {
         dispatch({
-            type: "resetOptions",
+            type: DISPATCH_ACTION.RESET_OPTIONS,
             value: options as PayPalScriptOptions,
         });
     }

--- a/src/types/scriptProviderTypes.ts
+++ b/src/types/scriptProviderTypes.ts
@@ -10,19 +10,19 @@ export interface ReactPayPalScriptOptions extends PayPalScriptOptions {
 
 export type ScriptReducerAction =
     | {
-          type: `${DISPATCH_ACTION.LOADING_STATUS}`;
+          type: DISPATCH_ACTION.LOADING_STATUS;
           value: SCRIPT_LOADING_STATE;
       }
     | {
-          type: `${DISPATCH_ACTION.LOADING_STATUS}`;
+          type: DISPATCH_ACTION.LOADING_STATUS;
           value: { state: SCRIPT_LOADING_STATE; message: string };
       }
     | {
-          type: `${DISPATCH_ACTION.RESET_OPTIONS}`;
+          type: DISPATCH_ACTION.RESET_OPTIONS;
           value: ReactPayPalScriptOptions;
       }
     | {
-          type: `${DISPATCH_ACTION.SET_BRAINTREE_INSTANCE}`;
+          type: DISPATCH_ACTION.SET_BRAINTREE_INSTANCE;
           value: BraintreePayPalCheckout;
       };
 


### PR DESCRIPTION
PR to simplify the type for the ScriptReducerAction (PayPalScriptProvider component).

This refactoring allows the use of this npm package in projects with lower TS versions, which doesn't support template literals in type definitions. Methods such as excluding in tsconfig, skipLibCheck, ts ignore, and no-check were unsuccessful.

The type definition has been simplified, and the test case updated.